### PR TITLE
chore: release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches:
       - main
+  release:
+    types:
+      - published
+      - released
 
 name: Build and deploy sites
 
@@ -98,29 +102,21 @@ jobs:
           fail: true
           args: --base './_out/html-multi/' --no-progress --offline './_out/html-multi/**/*.html'
 
-      # deploy-alias computes a stable, but difficult-to-guess, URL component
-      # for the PR preview. This is so we can have a stable name to use for
-      # feedback on draft material, but at the same time we avoid having
-      # something guessable by outsiders.
-      #
-      # SALT is a repository secret that contains some arbitrary string.
+      # deploy-alias computes a URL component for the PR preview. This
+      # is so we can have a stable name to use for feedback on draft
+      # material.
       - id: deploy-alias
         uses: actions/github-script@v7
         name: Compute Alias
         with:
           script: |
-            var crypto = require('crypto');
-            if (process.env.PR && process.env.SALT) {
-                var hash = crypto.createHash('sha256')
-                  .update(process.env.PR)
-                  .update(process.env.SALT)
-                  .digest('hex')
-                  .slice(0,8);
-                return `pr-${process.env.PR}-${hash}`
+            if (process.env.PR) {
+                return `pr-${process.env.PR}`
+            } else {
+                return 'main';
             }
         env:
           PR: ${{ github.event.number }}
-          SALT: ${{ secrets.SALT }}
 
         # deploy-info computes metadata that's shown in the Netlify interface
         # about the deployment (for non-PR deploys)
@@ -131,9 +127,29 @@ jobs:
           set -e
           echo "message=$(git log -1 --pretty=format:"%s")" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy
-        id: deploy
+      # When a release is created in GH, push to the main site without proofreading info
+      - name: Deploy releases when tags are pushed
+        id: deploy-release
         uses: nwtgck/actions-netlify@v2.0
+        if: github.event_name == 'release'
+        with:
+          publish-dir: _out/html-multi
+          production-branch: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: |
+            Release from tag ${{ github.ref }}
+          enable-commit-comment: false
+          enable-pull-request-comment: false
+          fails-without-credentials: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: "447031bf-9a96-4cee-831b-1f73599a7cb2"
+
+      # When pushing to `main` or a PR branch, deploy what it would look like if this were released
+      - name: Deploy current draft
+        id: deploy-draft
+        uses: nwtgck/actions-netlify@v2.0
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         with:
           publish-dir: _out/html-multi
           production-branch: main
@@ -150,8 +166,9 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: "447031bf-9a96-4cee-831b-1f73599a7cb2"
 
-      - name: Deploy with proofreading info (draft mode)
-        id: deploy-draft
+      # When pushing to `main` or a PR branch, deploy it with proofreading info as well
+      - name: Deploy with proofreading info (draft mode, for PRs)
+        id: deploy-draft-proofreading
         uses: nwtgck/actions-netlify@v2.0
         if:
           github.event_name == 'pull_request'


### PR DESCRIPTION
Updates CI as follows:
 * GitHub releases lead to deployments to main site
 * Pushes to `main` lead to an alternative prefix, instead of the main site
 * PRs work as before, but there's no more need for prefixes due to repository opening up today

This will require testing empirically, unfortunately!