### PR TITLE
fix: bump Verso to get trailing slashes in links

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -25,7 +25,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "e693406676e3a8bf5fe1013517ee00a0fbb3fbcc",
+   "rev": "08dd792c96ca545b29d9d398c531fc95eacf9dab",
    "name": "verso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
This will hopefully fix an issue with hosting.
