### PR TITLE
fix: use the correct `example` command

### DIFF
--- a/Manual/Language.lean
+++ b/Manual/Language.lean
@@ -13,8 +13,10 @@ import Manual.Language.InductiveTypes
 
 import Lean.Parser.Command
 
-open Verso.Genre Manual
-open Lean.Parser.Command (declModifiers)
+open Manual hiding «example»
+open Verso.Genre
+open Verso.Genre.Manual
+open Lean.Parser.Command (declModifiers «example»)
 
 set_option pp.rawOnError true
 
@@ -92,7 +94,7 @@ Definitional equality is used by conversion: if two terms are definitionally equ
 Because definitional equality includes reduction, types can result from computations over data.
 
 ::::keepEnv
-:::example "Computing types"
+:::Manual.example "Computing types"
 
 When passed a natural number, the function {lean}`LengthList` computes a type that corresponds to a list with precisely that many entries in it:
 
@@ -228,7 +230,7 @@ The specific rules depend on whether the return type of the function is a propos
 Predicates, which are functions that return propositions (that is, where the result type of the function is some type in `Prop`) may have argument types in any universe whatsoever, but the function type itself remains in `Prop`.
 In other words, propositions feature {deftech}[_impredicative_] {index}[impredicative]{index subterm := "impredicative"}[quantification] quantification, because propositions can themselves be statements about all propositions (and all other types).
 
-:::example "Impredicativity"
+:::Manual.example "Impredicativity"
 Proof irrelevance can be written as a proposition that quantifies over all propositions:
 ```lean
 example : Prop := ∀ (P : Prop) (p1 p2 : P), p1 = p2
@@ -244,7 +246,7 @@ example : Prop := ∀ (α : Type 5), ∀ (x : α), x = x
 For universes at {tech key:="universe level"}[level] `1` and higher (that is, the `Type u` hierarchy), quantification is {deftech}[_predicative_]. {index}[predicative]{index subterm := "predicative"}[quantification]
 For these universes, the universe of a function type is the least upper bound of the argument and return types' universes.
 
-:::example "Universe levels of function types"
+:::Manual.example "Universe levels of function types"
 Both of these types are in {lean}`Type 2`:
 ```lean
 example (α : Type 1) (β : Type 2) : Type 2 := α → β
@@ -252,7 +254,7 @@ example (α : Type 2) (β : Type 1) : Type 2 := α → β
 ```
 :::
 
-:::example "Predicativity of {lean}`Type`"
+:::Manual.example "Predicativity of {lean}`Type`"
 This example is not accepted, because `α`'s level is greater than `1`. In other words, the annotated universe is smaller than the function type's universe:
 ```lean error := true name:=toosmall
 example (α : Type 2) (β : Type 1) : Type 1 := α → β
@@ -270,7 +272,7 @@ but is expected to have type
 Lean's universes are not {deftech}[cumulative];{index}[cumulativity] a type in `Type u` is not automatically also in `Type (u + 1)`.
 Each type inhabits precisely one universe.
 
-:::example "No cumulativity"
+:::Manual.example "No cumulativity"
 This example is not accepted because the annotated universe is larger than the function type's universe:
 ```lean error := true name:=toobig
 example (α : Type 2) (β : Type 1) : Type 3 := α → β
@@ -291,7 +293,7 @@ Lean supports {deftech}_universe polymorphism_, {index subterm:="universe"}[poly
 These parameters can then be instantiated with universe levels when the constant is used.
 Universe parameters are written in curly braces following a dot after a constant name.
 
-:::example "Universe-polymorphic identity function"
+:::Manual.example "Universe-polymorphic identity function"
 When fully explicit, the identity function takes a universe parameter `u`. Its signature is:
 ```signature
 id.{u} {α : Sort u} (x : α) : α
@@ -302,7 +304,7 @@ Universe variables may additionally occur in {ref "level-expressions"}[universe 
 When the polymorphic definition is instantiated with concrete levels, these universe level expressions are also evaluated to yield concrete levels.
 
 ::::keepEnv
-:::example "Universe level expressions"
+:::Manual.example "Universe level expressions"
 
 In this example, {lean}`Codec` is in a universe that is one greater than the universe of the type it contains:
 ```lean
@@ -331,7 +333,7 @@ def Codec.char : Codec where
 
 Universe-polymorphic definitions in fact create a _schematic definition_ that can be instantiated at a variety of levels, and different instantiations of universes create incompatible values.
 
-:::example "Universe polymorhism is not first-class"
+:::Manual.example "Universe polymorhism is not first-class"
 
 This can be seen in the following example, in which `T` is a gratuitously-universe-polymorphic definition that always returns the constructor of the unit type.
 Both instantiations of `T` have the same value, and both have the same type, but their differing universe instantiations make them incompatible:
@@ -369,7 +371,7 @@ results in the signature:
 id'.{u} {α : Sort u} (x : α) : α
 ```
 
-:::example "Universe monomorphism in auto-bound implicit"
+:::Manual.example "Universe monomorphism in auto-bound implicit"
 On the other hand, because {name}`Nat` is in universe {lean}`Type 0`, this function automatically ends up with a concrete universe level for `α`, because `m` is applied to both {name}`Nat` and `α`, so both must have the same type and thus be in the same universe:
 ```lean
 partial def count [Monad m] (p : α → Bool) (act : m α) : m Nat := do
@@ -425,7 +427,7 @@ Explicit universe variable binding and instantiation occurs as a suffix to the d
 Universe parameters are defined or provided by suffixing the name of a constant with a period (`.`) followed by a comma-separated sequence of universe variables between curly braces.
 
 ::::keepEnv
-:::example "Universe-polymorphic `map`"
+:::Manual.example "Universe-polymorphic `map`"
 The following declaration of {lean}`map` declares two universe parameters (`u` and `v`) and instantiates the polymorphic {name}`List` with each in turn:
 ```lean
 def map.{u, v} {α : Type u} {β : Type v}
@@ -441,7 +443,7 @@ Just as Lean automatically instantiates implicit parameters, it also automatical
 When the {TODO}[describe this option and add xref] `autoImplicit` option is set to {lean}`true` (the default), it is not necessary to explicitly bind universe variables.
 When it is set to {lean}`false`, then they must be added explicitly or declared using the `universe` command. {TODO}[xref]
 
-::: example "Auto-implicits and universe polymorphism"
+:::Manual.example "Auto-implicits and universe polymorphism"
 When `autoImplicit` is {lean}`true` (which is the default setting), this definition is accepted even though it does not bind its universe parameters:
 ```lean (keep := false)
 set_option autoImplicit true
@@ -477,7 +479,7 @@ Declares one or more universe variables for the extent of the current scope.
 Just as the `variable` command causes a particular identifier to be treated as a parameter with a particular type, the `universe` command causes the subsequent identifiers to be implicitly quantified as as universe parameters in declarations that mention them, even if the option `autoImplicit` is {lean}`false`.
 :::
 
-:::example "The `universe` command when `autoImplicit` is `false`"
+:::Manual.example "The `universe` command when `autoImplicit` is `false`"
 ```lean (keep := false)
 set_option autoImplicit false
 universe u
@@ -487,7 +489,7 @@ def id₃ (α : Type u) (a : α) := a
 
 Because automatic implicit arguments only insert parameters that are used in the declaration's {tech}[header], universe variables that occur only on the right-hand side of a definition are not inserted as arguments unless they have been declared with `universe` even when `autoImplicit` is `true`.
 
-:::example "Automatic universe parameters and the `universe` command"
+:::Manual.example "Automatic universe parameters and the `universe` command"
 
 This definition with an explicit universe parameter is accepted:
 ```lean (keep := false)

--- a/Manual/Meta/Syntax.lean
+++ b/Manual/Meta/Syntax.lean
@@ -552,7 +552,7 @@ def syntaxKind : RoleExpander
     let id : Ident := mkIdentFrom syntaxKindName kName
     let k ← try realizeGlobalConstNoOverloadWithInfo id catch _ => pure kName
     let doc? ← findDocString? (← getEnv) k
-    return #[← `(Doc.Inline.other {Inline.syntaxKind with data := ToJson.toJson (α := Name × Option String) ($(quote k), $(quote doc?))} #[Doc.Inline.code $(quote k.toString)])]
+    return #[← `(Doc.Inline.other {Inline.syntaxKind with data := ToJson.toJson (α := Name × String × Option String) ($(quote k), $(quote syntaxKindName.getString), $(quote doc?))} #[Doc.Inline.code $(quote k.toString)])]
 
 
 @[inline_extension syntaxKind]
@@ -570,13 +570,13 @@ def syntaxKind.inlinedescr : InlineDescr where
   toHtml :=
     open Verso.Output.Html in
     some <| fun goI _ data inls => do
-      match FromJson.fromJson? (α := Name × Option String) data with
+      match FromJson.fromJson? (α := Name × String × Option String) data with
       | .error e =>
         Html.HtmlT.logError s!"Couldn't deserialize syntax kind name: {e}"
         return {{<code>{{← inls.mapM goI}}</code>}}
-      | .ok (k, doc?) =>
+      | .ok (k, showAs, doc?) =>
         return {{
           <code class="grammar">
-            {{← nonTermHtmlOf k doc? k.toString}}
+            {{← nonTermHtmlOf k doc? showAs}}
           </code>
         }}


### PR DESCRIPTION
Fixes #114.
