### PR TITLE
fix: bump Verso dep

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "b4623a7e137e1a987db9be2f599210bc6c5abda9",
+   "rev": "7d3a46ef38a48b9a5597fa543df918351a1876d1",
    "name": "verso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
This adds JS that adds trailing slashes to work around a hosting issue. This will let us disable the redirects on the server side that aren't being proxied correctly, at least as a temporary solution.

RE #224 