### PR TITLE
chore: add tag to header "Section Variables"

### DIFF
--- a/Manual/Language.lean
+++ b/Manual/Language.lean
@@ -418,6 +418,9 @@ unknown identifier 'cupcake'
 :::
 
 ### Section Variables
+%%%
+tag := "section-variables"
+%%%
 
 {deftech}_Section variables_ are parameters that are automatically added to declarations that mention them.
 This occurs whether or not the option {option}`autoImplicit` is {lean}`true`.


### PR DESCRIPTION
I'd like a tag on this section so that I can link to it.
