### PR TITLE
fix: remove a typo in WF.lean

### DIFF
--- a/Manual/RecursiveDefs/WF.lean
+++ b/Manual/RecursiveDefs/WF.lean
@@ -33,7 +33,7 @@ It does mean, however, that using these functions in types typically does not wo
 Even when the reduction behavior happens to hold definitionally, it is often much slower than structurally recursive definitions in the kernel, which must unfold the termination proof along with the definition.
 When possible, recursive function that are intended for use in types or in other situations where definitional equality is important should be defined with structural recursion.
 
-To explicitly use well-founded recursion recursion, a function or theorem definition can be annotated with a {keywordOf Lean.Parser.Command.declaration}`termination_by` clause that specifies the {deftech}_measure_ by which the function terminates.
+To explicitly use well-founded recursion, a function or theorem definition can be annotated with a {keywordOf Lean.Parser.Command.declaration}`termination_by` clause that specifies the {deftech}_measure_ by which the function terminates.
 The measure should be a term that decreases at each recursive call; it may be one of the function's parameters or a tuple of the parameters, but it may also be any other term.
 The measure's type must be equipped with a {tech}[well-founded relation], which determines what it means for the measure to decrease.
 


### PR DESCRIPTION
Just a redundant "recursion". Although the fact that the term "induction-recursion" exists makes me wonder if this isn't actually a typo :)
