### PR TITLE
fix: don't clobber messages

### DIFF
--- a/Manual/Classes.lean
+++ b/Manual/Classes.lean
@@ -273,7 +273,7 @@ def Heap.bubbleUp [Ord α] (i : Nat) (xs : Heap α) : Heap α :=
   else
     let j := i / 2
     if Ord.compare xs.contents[i] xs.contents[j] == .lt then
-      Heap.bubbleUp j {xs with contents := xs.contents.swap ⟨i, by omega⟩ ⟨j, by omega⟩}
+      Heap.bubbleUp j {xs with contents := xs.contents.swap i j}
     else xs
 
 def Heap.insert [Ord α] (x : α) (xs : Heap α) : Heap α :=
@@ -294,13 +294,12 @@ def Heap'.bubbleUp [inst : Ord α] (i : Nat) (xs : @Heap' α inst) : @Heap' α i
   else
     let j := i / 2
     if inst.compare xs.contents[i] xs.contents[j] == .lt then
-      Heap'.bubbleUp j {xs with contents := xs.contents.swap ⟨i, by omega⟩ ⟨j, by omega⟩}
+      Heap'.bubbleUp j {xs with contents := xs.contents.swap i j}
     else xs
 
 def Heap'.insert [Ord α] (x : α) (xs : Heap' α) : Heap' α :=
   let i := xs.contents.size
   {xs with contents := xs.contents.push x}.bubbleUp i
-end A
 ```
 
 In the improved definitions, {name}`Heap'.bubbleUp` is needlessly explicit; the instance does not need to be explicitly named here because Lean would select the indicated instances nonetheless, but it does bring the correctness invariant front and center for readers.

--- a/Manual/Classes/InstanceDecls.lean
+++ b/Manual/Classes/InstanceDecls.lean
@@ -268,8 +268,10 @@ However, because it is an ordinary Lean function, it can recursively refer to it
 instance instDecidableEqStringList : DecidableEq StringList
   | .nil, .nil => .isTrue rfl
   | .cons h1 t1, .cons h2 t2 =>
+    let _ : Decidable (t1 = t2) :=
+      instDecidableEqStringList t1 t2
     if h : h1 = h2 then
-      if h' : instDecidableEqStringList t1 t2 then
+      if h' : t1 = t2 then
         .isTrue (by simp [*])
       else
         .isFalse (by intro hEq; cases hEq; trivial)

--- a/Manual/Language.lean
+++ b/Manual/Language.lean
@@ -301,7 +301,7 @@ open Greetings
 
 The section's name must be used to close it.
 
-```lean (error := true) (name := english4)
+```lean (error := true) (name := english4) (keep := false)
 end
 ```
 ```leanOutput english4

--- a/Manual/Monads.lean
+++ b/Manual/Monads.lean
@@ -64,7 +64,6 @@ The {name}`Alternative` type class describes applicative functors that additiona
 ```lean (show := false)
 section
 variable {α : Type u} {β : Type u}
-variable {n : Nat}
 ```
 
 ::::example "Lists with Lengths as Applicative Functors"
@@ -113,7 +112,7 @@ instance : Applicative (LenList n) where
     list := List.replicate n x
     lengthOk := List.length_replicate _ _
   }
-  seq fs xs := fs.zipWith (· ·) (xs ())
+  seq {α β} fs xs := fs.zipWith (· ·) (xs ())
 ```
 
 The well-behaved {name}`Monad` instance takes the diagonal of the results of applying the function:
@@ -128,7 +127,8 @@ def LenList.diagonal (square : LenList n (LenList n α)) : LenList n α :=
   match n with
   | 0 => ⟨[], rfl⟩
   | n' + 1 => {
-    list := square.head.head :: (square.tail.map (·.tail)).diagonal.list,
+    list :=
+      square.head.head :: (square.tail.map (·.tail)).diagonal.list
     lengthOk := by simp
   }
 ```

--- a/Manual/Monads/Laws.lean
+++ b/Manual/Monads/Laws.lean
@@ -24,6 +24,8 @@ set_option linter.unusedVariables false
 tag := "monad-laws"
 %%%
 
+:::keepEnv
+
 ```lean (show := false)
 section Laws
 universe u u' v
@@ -38,7 +40,7 @@ axiom γ : Type u'
 axiom x : f α
 ```
 
-:::keepEnv
+
 ```lean (show := false)
 section F
 variable {f : Type u → Type v} [Functor f] {α β : Type u} {g : α → β} {h : β → γ} {x : f α}
@@ -64,7 +66,7 @@ The {name}`LawfulFunctor` class includes the necessary proofs.
 ```lean (show := false)
 end F
 ```
-:::
+
 
 In addition to proving that the potentially-optimized {name}`SeqLeft.seqLeft` and {name}`SeqRight.seqRight` operations are equivalent to their default implementations, Applicative functors {lean}`f` must satisfy four laws.
 
@@ -75,3 +77,5 @@ The {deftech}[monad laws] specify that {name}`pure` followed by {name}`bind` sho
 {docstring LawfulMonad}
 
 {docstring LawfulMonad.mk'}
+
+:::

--- a/Manual/Monads/Syntax.lean
+++ b/Manual/Monads/Syntax.lean
@@ -20,6 +20,8 @@ set_option pp.rawOnError true
 set_option linter.unusedVariables false
 -- set_option trace.SubVerso.Highlighting.Code true
 
+set_option guard_msgs.diff true
+
 #doc (Manual) "Syntax" =>
 
 Lean supports programming with functors, applicative functors, and monads via special syntax:
@@ -589,7 +591,7 @@ p : α → Prop
 inst✝ : DecidablePred p
 xs : Array α
 out✝ : Array Nat := #[]
-col✝ : Std.Range := { start := 0, stop := xs.size, step := 1 }
+col✝ : Std.Range := { start := 0, stop := xs.size, step := 1, step_pos := Nat.zero_lt_one }
 i : Nat
 r✝ : Array Nat
 out : Array Nat := r✝

--- a/Manual/Monads/Zoo.lean
+++ b/Manual/Monads/Zoo.lean
@@ -225,7 +225,7 @@ The standard library exports a mix of operations from the `-Of` and undecorated 
 ```lean (show := false)
 example : @get = @MonadState.get := by rfl
 example : @set = @MonadStateOf.set := by rfl
-example (f : σ → σ) : @modify σ m inst f = @MonadState.modifyGet σ m inst PUnit fun (s : σ) => (PUnit.unit, f s) := by rfl
+example {inst} (f : σ → σ) : @modify σ m inst f = @MonadState.modifyGet σ m inst PUnit fun (s : σ) => (PUnit.unit, f s) := by rfl
 example : @modifyGet = @MonadState.modifyGet := by rfl
 example : @read = @MonadReader.read := by rfl
 example : @readThe = @MonadReaderOf.read := by rfl

--- a/Manual/RecursiveDefs/Structural.lean
+++ b/Manual/RecursiveDefs/Structural.lean
@@ -328,7 +328,7 @@ Wrapping the discriminants in a pair breaks the connection.
 :::example "Structural Recursion Under Pairs"
 
 This function that finds the minimum of the two components of a pair can't be elaborated via structural recursion.
-```lean (error := true) (name := minpair)
+```lean (error := true) (name := minpair) (keep := false)
 def min' (nk : Nat × Nat) : Nat :=
   match nk with
   | (0, _) => 0
@@ -346,7 +346,7 @@ This is because the parameter's type, {name}`Prod`, is not recursive.
 Thus, its constructor has no recursive parameters that can be exposed by pattern matching.
 
 This definition is accepted using {tech}[well-founded recursion], however:
-```lean (keep := false)
+```lean
 def min' (nk : Nat × Nat) : Nat :=
   match nk with
   | (0, _) => 0

--- a/Manual/RecursiveDefs/WF.lean
+++ b/Manual/RecursiveDefs/WF.lean
@@ -370,10 +370,33 @@ def Tree.depth (t : Tree) : Nat :=
   | none => 0
 termination_by t
 decreasing_by
+  cases t
   decreasing_tactic
 ```
 
-Note that the proof goal after {keywordOf Lean.Parser.Command.declaration}`decreasing_by` now includes the assumption {lean}`c ∈ t.children`, which suffices for {tactic}`decreasing_tactic` to succeed.
+Note that the proof goal after {keywordOf Lean.Parser.Command.declaration}`decreasing_by` now includes the assumption {lean}`c ∈ t.children`.
+The initial goal, that {lean}`sizeOf c < sizeOf t.children`, can be simplified with the {tactic}`cases` tactic into one for which  {tactic}`decreasing_tactic` succeeds.
+
+```lean (keep := false) (show := false)
+/--
+error: failed to prove termination, possible solutions:
+  - Use `have`-expressions to prove the remaining goals
+  - Use `termination_by` to specify a different well-founded relation
+  - Use `decreasing_by` to specify your own tactic for discharging this kind of goal
+t c : Tree
+hc : c ∈ t.children
+⊢ sizeOf c < sizeOf t
+-/
+#guard_msgs in
+def Tree.depth (t : Tree) : Nat :=
+  let depths := t.children.attach.map (fun ⟨c, hc⟩ => Tree.depth c)
+  match depths.max? with
+  | some d => d+1
+  | none => 0
+termination_by t
+decreasing_by
+  decreasing_tactic
+```
 
 :::
 

--- a/Manual/Terms.lean
+++ b/Manual/Terms.lean
@@ -17,6 +17,7 @@ set_option linter.unusedVariables false
 open Lean.Elab.Tactic.GuardMsgs.WhitespaceMode
 
 set_option linter.constructorNameAsVariable false
+set_option guard_msgs.diff true
 
 #doc (Manual) "Terms" =>
 %%%
@@ -190,11 +191,11 @@ Even though `A` was opened more recently than the declaration of {name}`B.x`, th
 :::
 ::::
 
-::::keepEnv
+
 :::example "Ambiguous Identifiers"
 In this example, `x` could refer either to {name}`A.x` or {name}`B.x`, and neither takes precedence.
 Because both have the same type, it is an error.
-```lean (name := ambi)
+```lean (name := ambi) (error := true)
 def A.x := "A.x"
 def B.x := "B.x"
 open A
@@ -207,13 +208,11 @@ ambiguous, possible interpretations
 
   A.x : String
 ```
-```lean (show := false)
-```
 :::
-::::
-::::keepEnv
+
+
 :::example "Disambiguation via Typing"
-When they have different types, the types are used to disambiguate:
+When otherwise-ambiguous names have different types, the types are used to disambiguate:
 ```lean (name := ambiNo)
 def C.x := "C.x"
 def D.x := 3
@@ -225,7 +224,7 @@ open D
 "C.x"
 ```
 :::
-::::
+
 
 
 ## Leading `.`
@@ -870,7 +869,7 @@ axiom T.f : {n : Nat} → Char → T n → String
 
 Some functions are inconvenient to use with pipelines because their argument order is not conducive.
 For example, {name}`Array.push` takes an array as its first argument, not a {lean}`Nat`, leading to this error:
-```lean (name := arrPush)
+```lean (name := arrPush) (error := true)
 #eval #[1, 2, 3] |> Array.push 4
 ```
 ```leanOutput arrPush
@@ -1212,7 +1211,7 @@ They consist of the following:
 
 : Quoted names
 
-  Quoted names, such as {lean}`` `x `` and {lean}``` ``plus ```, match the corresponding {name}`Lean.Name` value.
+  Quoted names, such as {lean}`` `x `` and {lean}``` ``none ```, match the corresponding {name}`Lean.Name` value.
 
 : Macros
 
@@ -1385,7 +1384,7 @@ is not definitionally equal to the right-hand side
   3 = 5
 ⊢ 3 = 3 ∨ 3 = 5
 ---
-info: { val := 3, val2 := ?m.1487, ok := ⋯ } : OnlyThreeOrFive
+info: { val := 3, val2 := ?m.1542, ok := ⋯ } : OnlyThreeOrFive
 -/
 #guard_msgs in
 #check OnlyThreeOrFive.mk 3 ..

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "bef462ba6d207757d877d1e4488ccd9dfa2c8409",
+   "rev": "9c0d4a38c4ed8850882a057c3073e936f5495470",
    "name": "verso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
One of the scope preservation combinators was incorrectly clobbering the message log, which led to errors not being correctly registered. This has now been fixed, along with the errors in question.
