### PR TITLE
chore: bump Verso

### DIFF
--- a/Manual/Quotients.lean
+++ b/Manual/Quotients.lean
@@ -13,6 +13,8 @@ import Manual.Language.InductiveTypes
 
 open Verso.Genre Manual
 
+set_option maxHeartbeats 400000
+
 #doc (Manual) "Quotients" =>
 %%%
 tag := "quotients"

--- a/Manual/Tactics/Reference.lean
+++ b/Manual/Tactics/Reference.lean
@@ -19,7 +19,7 @@ set_option pp.rawOnError true
 
 set_option linter.unusedVariables false
 
-set_option maxHeartbeats 300000
+set_option maxHeartbeats 400000
 
 #doc (Manual) "Tactic Reference" =>
 %%%

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "91d124285fd99be006c508cd40bc2df370255bf7",
+   "rev": "2840b6d06a3b4008b050e527334e9c864986f659",
    "name": "verso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
This gets access to the page-local ToC items in the upstream library, including sub*sections.

Closes #236