### PR TITLE
fix: scope LI spacing fixes more specifically

### DIFF
--- a/static/theme.css
+++ b/static/theme.css
@@ -34,17 +34,16 @@ div.paragraph > dl:not(:last-child) {
 /*
 Don't impose margins on lists or list items from their contents.
 */
-li > :first-child {
+main section li > :first-child {
   margin-top: 0;
 }
-li > :last-child {
+main section li > :last-child {
   margin-bottom: 0;
 }
-
-li:not(:first-child) {
+main section li:not(:first-child) {
   margin-top: 0.5rem;
 }
-li:not(:last-child) {
+main section li:not(:last-child) {
   margin-bottom: 0.5rem;
 }
 


### PR DESCRIPTION
They only apply to the text, not the navigation.
