### PR TITLE
fix: make distance between list element title and sublist the same

### DIFF
--- a/static/theme.css
+++ b/static/theme.css
@@ -55,6 +55,9 @@ main section li:not(:first-child) {
 main section li:not(:last-child) {
   margin-bottom: 0.5rem;
 }
+main section li ol {
+  margin-top: .5rem;
+}
 
 .hl.lean.block {
     margin-top: 1em;


### PR DESCRIPTION
This has annoyed me for a while. It seems something has changed in the rendering of the contents on the chapter-pages, so they don't show the sub-lists anymore. But the index still does. This changes the index from looking like this:

<img width="444" alt="Screenshot 2025-03-08 at 08 31 19" src="https://github.com/user-attachments/assets/0490d37e-ee2c-434a-9bf2-2316a76ce197" />

To looking like this:

<img width="437" alt="Screenshot 2025-03-08 at 08 31 28" src="https://github.com/user-attachments/assets/e6139391-73cd-4556-8c88-64abc31b912c" />