### PR TITLE
fix: fallback for the quick jump when the title is too long for small screens

### DIFF
--- a/static/search/search-box.css
+++ b/static/search/search-box.css
@@ -177,4 +177,14 @@
 #search-wrapper {
   width: fit-content;
   z-index: 1;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0 .5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: white;
 }

--- a/static/theme.css
+++ b/static/theme.css
@@ -122,3 +122,14 @@ figcaption {
 #toc .split-toc > ol .tactic-name {
   font-weight: 600;
 }
+
+/* Move the title from the header to the toc when there is not enough room for the quick jump bar. */
+@media screen and (max-width: 1100px) {
+  .toc-title {
+    display: block;
+  }
+
+  .header-title {
+    display: none;
+  }
+}


### PR DESCRIPTION
It will now slide over the title, instead of sliding off the screen.

This is built on top of, but can be merged without https://github.com/leanprover/verso/pull/315.

Closes #318 .