### PR TITLE
fix: synchronize display of syntax errors with Lean language server

### DIFF
--- a/Manual/BasicTypes/BitVec.lean
+++ b/Manual/BasicTypes/BitVec.lean
@@ -86,14 +86,14 @@ Spaces are not allowed on either side of the `#`:
 5 #8
 ```
 ```leanOutput spc1
-<example>:1:2: expected end of input
+<example>:1:2-1:3: expected end of input
 ```
 
 ```syntaxError spc2 (category := term)
 5# 8
 ```
 ```leanOutput spc2
-<example>:1:3: expected no space before
+<example>:1:3-1:4: expected no space before
 ```
 
 
@@ -103,7 +103,7 @@ A numeric literal is required to the left of the `#`:
 (3 + 2)#8
 ```
 ```leanOutput spc3
-<example>:1:7: expected end of input
+<example>:1:7-1:8: expected end of input
 ```
 
 

--- a/Manual/BasicTypes/Products.lean
+++ b/Manual/BasicTypes/Products.lean
@@ -231,7 +231,7 @@ The two styles of annotation cannot be mixed in a single {keywordOf «termΣ_,_�
 Σ n k (i : Fin (n * k)) , Fin i.val
 ```
 ```leanOutput mixedNesting
-<example>:1:6: expected ','
+<example>:1:5-1:7: unexpected token '('; expected ','
 ```
 ::::
 

--- a/Manual/BasicTypes/String/Literals.lean
+++ b/Manual/BasicTypes/String/Literals.lean
@@ -67,7 +67,7 @@ def str3 := "String with \
 ```
 The parser error is:
 ```leanOutput foo
-<example>:2:0: unexpected additional newline in string gap
+<example>:2:0-3:0: unexpected additional newline in string gap
 ```
 
 # Interpolated Strings
@@ -80,7 +80,10 @@ Interpolated strings are interpreted by appending the string that precedes the i
 
 For example:
 ```lean
-example : s!"1 + 1 = {1 + 1}\n" = "1 + 1 = " ++ toString (1 + 1) ++ "\n" := rfl
+example :
+    s!"1 + 1 = {1 + 1}\n" =
+    "1 + 1 = " ++ toString (1 + 1) ++ "\n" :=
+  rfl
 ```
 
 Preceding a literal with `m!` causes the interpolation to result in an instance of {name Lean.MessageData}`MessageData`, the compiler's internal data structure for messages to be shown to users.
@@ -106,11 +109,17 @@ The `#eval` yields:
 Including hash marks allows the strings to contain unescaped quotes:
 
 ```lean
-example : r#"This is "literally" quoted"# = "This is \"literally\" quoted" := rfl
+example :
+    r#"This is "literally" quoted"# =
+    "This is \"literally\" quoted" :=
+  rfl
 ```
 
 Adding sufficiently many hash marks allows any raw literal to be written literally:
 
 ```lean
-example : r##"This is r#"literally"# quoted"## = "This is r#\"literally\"# quoted" := rfl
+example :
+    r##"This is r#"literally"# quoted"## =
+    "This is r#\"literally\"# quoted" :=
+  rfl
 ```

--- a/Manual/Intro.lean
+++ b/Manual/Intro.lean
@@ -132,7 +132,7 @@ skip
 
 Identifiers in code examples are hyperlinked to their documentation.
 
-Examples of code with syntax errors are shown with an indicator of where the parser stopped, along with the error message:
+Examples of code with syntax errors are shown with an indicator of where the parser error occurred, along with the error message:
 ```syntaxError intro
 def f : Option Nat → Type
   | some 0 => Unit
@@ -140,7 +140,7 @@ def f : Option Nat → Type
   | none => Empty
 ```
 ```leanOutput intro
-<example>:3:4: expected term
+<example>:3:3-3:6: unexpected token '=>'; expected term
 ```
 
 ## Examples

--- a/Manual/Meta/Basic.lean
+++ b/Manual/Meta/Basic.lean
@@ -75,6 +75,55 @@ def parserInputString [Monad m] [MonadFileMap m]
   code := code ++ strOriginal?.getD str.getString
   return code
 
+structure SyntaxError where
+  pos : Position
+  endPos : Position
+  text : String
+deriving ToJson, FromJson, BEq, Repr
+
+open Lean.Syntax in
+instance : Quote Position where
+  quote
+    | .mk l c => mkCApp ``Position.mk #[quote l, quote c]
+
+open Lean.Syntax in
+instance : Quote SyntaxError where
+  quote
+    | .mk pos endPos text => mkCApp ``SyntaxError.mk #[quote pos, quote endPos, quote text]
+
+-- Based on mkErrorMessage used in Lean upstream - keep them in synch for best UX
+open Lean.Parser in
+private partial def mkSyntaxError (c : InputContext) (pos : String.Pos) (stk : SyntaxStack) (e : Parser.Error) : SyntaxError := Id.run do
+  let mut pos := pos
+  let mut endPos? := none
+  let mut e := e
+  unless e.unexpectedTk.isMissing do
+    -- calculate error parts too costly to do eagerly
+    if let some r := e.unexpectedTk.getRange? then
+      pos := r.start
+      endPos? := some r.stop
+    let unexpected := match e.unexpectedTk with
+      | .ident .. => "unexpected identifier"
+      | .atom _ v => s!"unexpected token '{v}'"
+      | _         => "unexpected token"  -- TODO: categorize (custom?) literals as well?
+    e := { e with unexpected }
+    -- if there is an unexpected token, include preceding whitespace as well as the expected token could
+    -- be inserted at any of these places to fix the error; see tests/lean/1971.lean
+    if let some trailing := lastTrailing stk then
+      if trailing.stopPos == pos then
+        pos := trailing.startPos
+  return {
+    pos := c.fileMap.toPosition pos
+    endPos := (c.fileMap.toPosition <$> endPos?).getD (c.fileMap.toPosition (pos + c.input.get pos))
+    text := toString e
+  }
+where
+  -- Error recovery might lead to there being some "junk" on the stack
+  lastTrailing (s : SyntaxStack) : Option Substring :=
+    s.toSubarray.findSomeRevM? (m := Id) fun stx =>
+      if let .original (trailing := trailing) .. := stx.getTailInfo then pure (some trailing)
+        else none
+
 open Lean.Parser in
 def runParserCategory (env : Environment) (opts : Lean.Options) (catName : Name) (input : String) (fileName : String := "<example>") : Except (List (Position × String)) Syntax :=
     let p := andthenFn whitespace (categoryParserFnImpl catName)
@@ -93,6 +142,25 @@ where
       let pos := ctx.fileMap.toPosition pos
       errs := (pos, toString err) :: errs
     errs.reverse
+
+
+open Lean.Parser in
+/--
+A version of `Manual.runParserCategory` that returns syntax errors located the way Lean does.
+-/
+def runParserCategory' (env : Environment) (opts : Lean.Options) (catName : Name) (input : String) (fileName : String := "<example>") : Except (Array SyntaxError) Syntax :=
+    let p := andthenFn whitespace (categoryParserFnImpl catName)
+    let ictx := mkInputContext input fileName
+    let s := p.run ictx { env, options := opts } (getTokenTable env) (mkParserState input)
+    if !s.allErrors.isEmpty then
+      Except.error <| toSyntaxErrors ictx s
+    else if ictx.input.atEnd s.pos then
+      Except.ok s.stxStack.back
+    else
+      Except.error (toSyntaxErrors ictx (s.mkError "end of input"))
+where
+  toSyntaxErrors (ictx : InputContext) (s : ParserState) : Array SyntaxError :=
+    s.allErrors.map fun (pos, stk, e) => (mkSyntaxError ictx pos stk e)
 
 open Lean.Parser in
 def runParser

--- a/Manual/NotationsMacros.lean
+++ b/Manual/NotationsMacros.lean
@@ -503,7 +503,7 @@ Spaces are not allowed between the dollar sign and the identifier.
 def ex2 (e) := show m _ from `(2 + $ e:num)
 ```
 ```leanOutput ex2err1
-<example>:1:35: expected '`(tactic|' or no space before spliced term
+<example>:1:34-1:36: unexpected token '$'; expected '`(tactic|' or no space before spliced term
 ```
 
 Spaces are also not allowed before the colon:
@@ -511,7 +511,7 @@ Spaces are also not allowed before the colon:
 def ex2 (e) := show m _ from `(2 + $e :num)
 ```
 ```leanOutput ex2err2
-<example>:1:38: expected ')'
+<example>:1:37-1:39: unexpected token ':'; expected ')'
 ```
 ::::
 :::::

--- a/Manual/NotationsMacros/Notations.lean
+++ b/Manual/NotationsMacros/Notations.lean
@@ -151,7 +151,7 @@ However, the ignored term must still be syntactically valid:
 #eval ignore (2 +) 5
 ```
 ```leanOutput ignore'
-<example>:1:17: expected term
+<example>:1:17-1:18: unexpected token ')'; expected term
 ```
 :::
 ::::

--- a/Manual/NotationsMacros/Operators.lean
+++ b/Manual/NotationsMacros/Operators.lean
@@ -55,7 +55,7 @@ Infix operators additionally have an {deftech}_associativity_ that determines th
   ```
   The parser error is:
   ```leanOutput eqs
-  <example>:1:10: expected end of input
+  <example>:1:10-1:11: expected end of input
   ```
 ::::keepEnv
 :::example "Precedence for Prefix and Infix Operators"

--- a/Manual/NotationsMacros/SyntaxDef.lean
+++ b/Manual/NotationsMacros/SyntaxDef.lean
@@ -684,7 +684,7 @@ Similarly, parsing fails when they are mismatched:
 example := balanced [() (]]
 ```
 ```leanOutput mismatch
-<example>:1:25: expected ')' or balanced
+<example>:1:25-1:26: unexpected token ']'; expected ')' or balanced
 ```
 :::
 ::::
@@ -790,7 +790,7 @@ The following examples are not syntactically valid because the columns of the bu
    • "Two"
 ```
 ```leanOutput noteEx2
-<example>:4:3: expected end of input
+<example>:4:3-4:4: expected end of input
 ```
 
 ```syntaxError noteEx2
@@ -800,7 +800,7 @@ The following examples are not syntactically valid because the columns of the bu
      • "Two"
 ```
 ```leanOutput noteEx2
-<example>:4:5: expected end of input
+<example>:4:5-4:6: expected end of input
 ```
 :::
 ::::

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "c0fc0f66c175330ad6ebc03344480c4ace1eb0dd",
+   "rev": "dcee04af0f379159c1d87ebcbd2edd2b7087b98d",
    "name": "verso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
Before, the parser's stopping position was indicated, but this was confusing. Now, the same heuristic as the language server is used to assign a range to the syntax error display, and it looks like other rendered errors.