### PR TITLE
feat: limit footnote width when content is centered on a large screen

### DIFF
--- a/Manual/Meta/Marginalia.lean
+++ b/Manual/Meta/Marginalia.lean
@@ -21,14 +21,23 @@ def Marginalia.css := r#"
   position: relative;
   padding: 0.5rem;
 }
+
 /* Wide viewport */
 @media screen and (min-width: 1400px) {
   .marginalia .note {
     float: right;
     clear: right;
+    margin-right: -16rem;
+    width: 13rem;
+    margin-top: 1rem;
+  }
+}
+
+/* Very wide viewport */
+@media screen and (min-width: 1600px) {
+  .marginalia .note {
     margin-right: -19vw;
     width: 15vw;
-    margin-top: 1rem;
   }
 }
 


### PR DESCRIPTION
Otherwise they go over the edge of the page.

Requires https://github.com/leanprover/verso/pull/326 before it makes sense.