### PR TITLE
fix: couple the term and domain in the quick jump bar tighter on mobile

### DIFF
--- a/static/search/search-box.css
+++ b/static/search/search-box.css
@@ -102,6 +102,15 @@
   scroll-margin-bottom: 1.2rem;
 }
 
+/* Couple the domain tighter with the search term on smaller screens,
+   otherwise it's easy to get lost in the results. */
+@media screen and (max-width: 700px) {
+  #search-wrapper .search-result {
+    gap: 0;
+    padding: .3rem .2rem;
+  }
+}
+
 #search-wrapper .search-result.doc-domain,
 #search-wrapper .search-result.option-domain,
 #search-wrapper .search-result.syntax-domain,
@@ -137,6 +146,16 @@
   border-top: 1px solid currentColor;
 }
 
+/* Couple the domain tighter with the search term on smaller screens,
+   otherwise it's easy to get lost in the results. */
+@media screen and (max-width: 700px) {
+#search-wrapper [role="listbox"].focus li[aria-selected="true"],
+#search-wrapper .search-result:hover {
+    padding-bottom: calc(.3rem - 1px);
+    padding-top: calc(.3rem - 1px);
+  }
+}
+
 #search-wrapper .search-result p {
   margin: 0;
   font-family: inherit;
@@ -156,6 +175,14 @@
   font-family: var(--verso-structure-font-family);
   font-weight: normal;
   font-size: .7rem;
+}
+
+/* Couple the domain tighter with the search term on smaller screens,
+   otherwise it's easy to get lost in the results. */
+@media screen and (max-width: 700px) {
+  #search-wrapper .search-result .domain {
+    text-align: left;
+  }
 }
 
 #search-wrapper .more-results {


### PR DESCRIPTION
![Screen Shot 2025-03-16 at 13 51 11](https://github.com/user-attachments/assets/94b8d9a9-e68f-4f05-9187-6a7bbbe39f6d)

I'd like a second opinion before we merge this. I think it's better than what we have currently for mobile, but I think @ashandoak should take a look too.