### PR TITLE
feat: ensure that `Nat` docstring information ends up here

### DIFF
--- a/Manual/BasicTypes/Nat.lean
+++ b/Manual/BasicTypes/Nat.lean
@@ -21,7 +21,7 @@ The {deftech}[natural numbers] are nonnegative integers.
 Logically, they are the numbers 0, 1, 2, 3, …, generated from the constructors {lean}`Nat.zero` and {lean}`Nat.succ`.
 Lean imposes no upper bound on the representation of natural numbers other than physical constraints imposed by the available memory of the computer.
 
-Because the natural numbers are fundamental to both mathematical reasoning and programming, they are specially supported by Lean's implementation. The logical model of the natural numbers is as an {tech}[inductive type], and arithmetic operations are specified using this model. In Lean's kernel, the interpreter, and compiled code, closed natural numbers are represented as efficient arbitrary-precision integers. Sufficiently small numbers are immediate values that don't require indirection through a pointer. Arithmetic operations are implemented by primitives that take advantage of the efficient representations.
+Because the natural numbers are fundamental to both mathematical reasoning and programming, they are specially supported by Lean's implementation. The logical model of the natural numbers is as an {tech}[inductive type], and arithmetic operations are specified using this model. In Lean's kernel, the interpreter, and compiled code, closed natural numbers are represented as efficient arbitrary-precision integers. Sufficiently small numbers are unboxed values that don't require indirection through a pointer. Arithmetic operations are implemented by primitives that take advantage of the efficient representations.
 
 # Logical Model
 %%%
@@ -30,6 +30,35 @@ tag := "nat-model"
 
 
 {docstring Nat}
+
+::::leanSection
+```lean (show := false)
+variable (i : Nat)
+```
+:::example "Proofs by Induction"
+The natural numbers are an {tech}[inductive type], so the {tactic}`induction` tactic can be used to prove universally-quantified statements.
+A proof by induction requires a base case and an induction step.
+The base case is a proof that the statement is true for `0`.
+The induction step is a proof that the truth of the statement for some arbitrary number {lean}`i` implies its truth for {lean}`i + 1`.
+
+This proof uses the lemma `Nat.succ_lt_succ` in its induction step.
+```lean
+example (n : Nat) : n < n + 1 := by
+  induction n with
+  | zero =>
+    show 0 < 1
+    decide
+  | succ i ih => -- ih : i < i + 1
+    show i + 1 < i + 1 + 1
+    exact Nat.succ_lt_succ ih
+```
+:::
+::::
+
+## Peano Axioms
+%%%
+tag := "peano-axioms"
+%%%
 
 The Peano axioms are a consequence of this definition.
 The induction principle generated for {lean}`Nat` is the one demanded by the axiom of induction:
@@ -64,6 +93,14 @@ theorem succ_not_zero : ¬n + 1 = 0 := noConfusion (n + 1) 0
 tag := "nat-runtime"
 %%%
 
+The representation suggested by the declaration of `Nat` would be horrendously inefficient, as it's essentially a linked list.
+The length of the list would be the number.
+With this representation, addition would take time linear in the size of one of the addends, and numbers would take at least as many machine words as their magnitude in memory.
+Thus, natural numbers have special support in both the kernel and the compiler that avoids this overhead.
+
+In the kernel, there are special `Nat` literal values that use a widely-trusted, efficient arbitrary-precision integer library (usually [GMP](https://gmplib.org/)).
+Basic functions such as addition are overridden by primitives that use this representation.
+Because they are part of the kernel, if these primitives did not correspond to their definitions as Lean functions, it could undermine soundness.
 
 In compiled code, sufficiently-small natural numbers are represented as unboxed values: the lowest-order bit in an object pointer is used to indicate that the value is not, in fact, a pointer, and the remaining bits are used to store the number.
 31 bits are available on 32-bits architectures for unboxed {lean}`Nat`s, while 63 bits are available on 64-bit architectures.

--- a/Manual/BasicTypes/Nat.lean
+++ b/Manual/BasicTypes/Nat.lean
@@ -83,9 +83,11 @@ theorem noConfusionDiagonal (n : Nat) : NoConfusion n n :=
 theorem noConfusion (n k : Nat) (eq : n = k) : NoConfusion n k :=
   eq ▸ noConfusionDiagonal n
 
-theorem succ_injective : n + 1 = k + 1 → n = k := noConfusion (n + 1) (k + 1)
+theorem succ_injective : n + 1 = k + 1 → n = k :=
+  noConfusion (n + 1) (k + 1)
 
-theorem succ_not_zero : ¬n + 1 = 0 := noConfusion (n + 1) 0
+theorem succ_not_zero : ¬n + 1 = 0 :=
+  noConfusion (n + 1) 0
 ```
 
 # Run-Time Representation


### PR DESCRIPTION
The docstring for `Nat` was very long, but had good information. Now it's moved here, in preparation for merging the PR that simplifies the docstring.

Closes #365 