### PR TITLE
fix: several small UI fixes

### DIFF
--- a/.vale/styles/config/ignore/terms.txt
+++ b/.vale/styles/config/ignore/terms.txt
@@ -2,6 +2,7 @@ APIs
 Abelian
 Ackermann
 Kleisli
+Nullability
 Packrat
 antiquotation
 antiquotation's
@@ -104,6 +105,7 @@ namespace's
 namespaces
 nonterminal
 nonterminals
+nullability
 nullable
 nullary
 parameters'

--- a/Manual/Meta/Example.lean
+++ b/Manual/Meta/Example.lean
@@ -103,16 +103,17 @@ def example.descr : BlockDescr where
         pure {{
           <details class="example" {{attrs}}>
             <summary class="description">{{← description.mapM goI}}</summary>
-            {{← blocks.extract 1 blocks.size |>.mapM goB}}
+            <div class="example-content">
+              {{← blocks.extract 1 blocks.size |>.mapM goB}}
+            </div>
           </details>
         }}
   extraCss := [
 r#".example {
-  padding: 1.5em;
   border: 1px solid #98B2C0;
-  border-radius: 0.5em;
-  margin-bottom: 0.75em;
-  margin-top: 0.75em;
+  border-radius: 0.5rem;
+  margin-bottom: 0.75rem;
+  margin-top: 0.75rem;
 }
 /* 1400 px is the cutoff for when the margin notes move out of the margin and into floated elements. */
 @media screen and (700px < width <= 1400px) {
@@ -120,16 +121,25 @@ r#".example {
     clear: both; /* Don't overlap margin notes with examples */
   }
 }
-.example p:last-child {margin-bottom:0;}
 .example .description::before {
   content: "Example: ";
-}
-.example[open] .description {
-  margin-bottom: 1em;
 }
 .example .description {
   font-style: italic;
   font-family: var(--verso-structure-font-family);
+  padding: 1.5rem;
+}
+.example[open] .description {
+  margin-bottom: 0;
+}
+.example-content {
+  padding: 0 1.5rem 1.5rem;
+}
+.example-content > :first-child {
+  margin-top: 0;
+}
+.example-content p:last-child {
+  margin-bottom:0;
 }
 .example .hl.lean.block {
   overflow-x: auto;

--- a/Manual/Meta/Lean/IO.lean
+++ b/Manual/Meta/Lean/IO.lean
@@ -125,6 +125,11 @@ def Block.exampleFile.descr : BlockDescr where
   width: fit-content;
   border: 1px solid #ddd;
   padding: 0.5rem;
+
+  /* These are necessary for the container to behave nicely on mobile */
+  overflow-x: auto;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 .example-file::before {
   counter-reset: linenumber;

--- a/Manual/Meta/Marginalia.lean
+++ b/Manual/Meta/Marginalia.lean
@@ -52,7 +52,7 @@ def Marginalia.css := r#"
     clear: right;
     width: 40%;
     margin: 1rem 0;
-    margin-left: 5%;
+    margin-left: 10%;
   }
 }
 

--- a/Manual/Meta/Syntax.lean
+++ b/Manual/Meta/Syntax.lean
@@ -1195,9 +1195,9 @@ r#"
   font-family: var(--verso-structure-font-family);
   font-size: larger;
   margin-top: 0;
-  margin-left: 1.5em;
-  margin-right: 1.5em;
-  margin-bottom: 0.5em;
+  margin-left: 1rem;
+  margin-right: 1.5rem;
+  margin-bottom: 0.75rem;
   display: inline-block;
 }
 "#

--- a/static/theme.css
+++ b/static/theme.css
@@ -110,7 +110,7 @@ figcaption {
 
 /* Different color for warning */
 .warning pre, .warning code {
-    border-color: #efd871;
+    border-color: var(--verso-warning-color);
 }
 
 /* Different color for information */


### PR DESCRIPTION
fix: display the label consistently over namedocs headers

fix: overflowing code examples, IO

fix: centralize warning color

fix: make example header fully clickable

Examples were only clickable on the line of the text. Now the whole
header is clickable.

fix: increase side margin for marginalia on medium screens