### PR TITLE
fix: parameter scope example

### DIFF
--- a/Manual/Defs.lean
+++ b/Manual/Defs.lean
@@ -231,7 +231,7 @@ The parameter `n` is in scope in the function's body, but `k` is not.
 ```lean
 def add (n : Nat) : (k : Nat) → Nat
   | 0 => n
-  | k' + 1 => add n k'
+  | k' + 1 => 1 + add n k'
 ```
 
 Like {lean}`add`, the signature of {lean}`mustBeEqual` contains one parameter, `n`.


### PR DESCRIPTION
The name of the `add` definition suggests that it can be used to calculate the sum of two natural numbers, but in the current form, it is always evaluated to the parameter `n` instead of `n+m`
