### PR TITLE
chore: avoid repeated "Mismatched <foo> output output" in `expectString` error message

### DIFF
--- a/Manual/Meta/ExpectString.lean
+++ b/Manual/Meta/ExpectString.lean
@@ -30,7 +30,7 @@ If the strings don't match, then a diff is displayed as an error, and a code act
 expected string with the actual one is offered. Strings are compared one line at a time, and only
 strings that match `useLine` are considered (by default, all are considered). Lines are compared
 modulo `preEq`. The parameter `what` is used in the error message header, in a context "Mismatched
-`what` output:".
+`what`:".
 
 Errors are logged, not thrown; the returned `Bool` indicates whether an error was logged.
 -/
@@ -42,7 +42,7 @@ def expectString (what : String) (expected : StrLit) (actual : String)
 
   unless expectedLines.map preEq == actualLines.map preEq do
     let diff := Diff.diff expectedLines actualLines
-    logErrorAt expected m!"Mismatched {what} output:\n{Diff.linesToString diff}"
+    logErrorAt expected m!"Mismatched {what}:\n{Diff.linesToString diff}"
     Suggestion.saveSuggestion expected (abbreviateString actual) actual
     return false
 

--- a/Manual/Meta/LakeToml.lean
+++ b/Manual/Meta/LakeToml.lean
@@ -796,7 +796,7 @@ def lakeToml : DirectiveExpander
           | .ok v => pure v
         | _, _ => throwError s!"Unsupported type {opts.type}"
 
-        discard <| expectString "elaborated configuration" expectedStr v (useLine := (·.any (!·.isWhitespace)))
+        discard <| expectString "elaborated configuration output" expectedStr v (useLine := (·.any (!·.isWhitespace)))
 
         contents.mapM (elabBlock ⟨·⟩)
 


### PR DESCRIPTION
Example issue:

```
✖ [469/477] Building Manual.BuildTools.Elan
error: reference-manual/Manual/BuildTools/Elan.lean:226:0: Mismatched 'elan --help' output output:
                                                                                    ^^^^^^^^^^^^^
```

`main` branch:

```
Manual/Meta/ExpectString.lean:    logErrorAt expected m!"Mismatched {what} output:\n{Diff.linesToString diff}"
…
Manual/Meta/ElanCheck.lean:    discard <| expectString "'elan --help' output" str elanOutput (useLine := useLine) (preEq := String.trimRight)
Manual/Meta/ExpectString.lean:def expectString (what : String) (expected : StrLit) (actual : String)
Manual/Meta/LakeCheck.lean:    discard <| expectString "'lake --help' output" str lakeOutput (useLine := useLine)
Manual/Meta/LakeToml.lean:        discard <| expectString "elaborated configuration" expectedStr v (useLine := (·.any (!·.isWhitespace)))
```

This branch:

```
Manual/Meta/ExpectString.lean:    logErrorAt expected m!"Mismatched {what}:\n{Diff.linesToString diff}"
…
Manual/Meta/ElanCheck.lean:    discard <| expectString "'elan --help' output" str elanOutput (useLine := useLine) (preEq := String.trimRight)
Manual/Meta/ExpectString.lean:def expectString (what : String) (expected : StrLit) (actual : String)
Manual/Meta/LakeCheck.lean:    discard <| expectString "'lake --help' output" str lakeOutput (useLine := useLine)
Manual/Meta/LakeToml.lean:        discard <| expectString "elaborated configuration output" expectedStr v (useLine := (·.any (!·.isWhitespace)))
```