### PR TITLE
chore: bump `nightly-testing` to `2025-06-24`

### DIFF
--- a/Manual/BuildTools/Lake/CLI.lean
+++ b/Manual/BuildTools/Lake/CLI.lean
@@ -391,7 +391,8 @@ The initial configuration and starter files are based on the template:
   std                   library and executable; default
   exe                   executable only
   lib                   library only
-  math                  library only with a mathlib dependency
+  math-lax              library only with a Mathlib dependency
+  math                  library with Mathlib standards for linting and workflows
 
 Templates can be suffixed with `.lean` or `.toml` to produce a Lean or TOML
 version of the configuration file, respectively. The default is TOML.

--- a/Manual/RecursiveDefs/Structural/CourseOfValuesExample.lean
+++ b/Manual/RecursiveDefs/Structural/CourseOfValuesExample.lean
@@ -21,7 +21,7 @@ open Lean.Elab.Tactic.GuardMsgs.WhitespaceMode
 This definition is equivalent to {name}`List.below`:
 ```lean
 def List.below' {α : Type u} {motive : List α → Sort u} :
-    List α → Sort (max 1 u)
+    List α → Sort (max (u + 1) u)
   | [] => PUnit
   | _ :: xs => motive xs ×' xs.below' (motive := motive)
 ```
@@ -46,7 +46,7 @@ inductive Tree (α : Type u) : Type u where
 Its corresponding course-of-values table contains the realizations of the motive for all subtrees:
 ```lean
 def Tree.below' {α : Type u} {motive : Tree α → Sort u} :
-    Tree α → Sort (max 1 u)
+    Tree α → Sort (max (u + 1) u)
   | .leaf => PUnit
   | .branch left _val right =>
     (motive left ×' left.below' (motive := motive)) ×'

--- a/Manual/Tactics.lean
+++ b/Manual/Tactics.lean
@@ -863,22 +863,22 @@ Generally speaking, {tactic}`have` should be used when proving an intermediate l
 :::tactic "have"
 :::
 
-:::tactic Lean.Parser.Tactic.tacticHaveI_
+:::tactic Lean.Parser.Tactic.tacticHave__
 :::
 
-:::tactic Lean.Parser.Tactic.tacticHave'_
+:::tactic Lean.Parser.Tactic.tacticHave'
 :::
 
-:::tactic Lean.Parser.Tactic.tacticLet_ show:="let"
+:::tactic Lean.Parser.Tactic.tacticLet__ show:="let"
 :::
 
 :::tactic Lean.Parser.Tactic.letrec show:="let rec"
 :::
 
-:::tactic Lean.Parser.Tactic.tacticLetI_
+:::tactic Lean.Parser.Tactic.tacticLetI__
 :::
 
-:::tactic Lean.Parser.Tactic.tacticLet'_
+:::tactic Lean.Parser.Tactic.tacticLet'__
 :::
 
 ## Configuration

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2025-06-23
+leanprover/lean4:nightly-2025-06-24


### PR DESCRIPTION
This PR bumps the nightly testing Lean version to `2025-06-24`.