### PR TITLE
doc: swap sides of equality in grind

### DIFF
--- a/Manual/Grind.lean
+++ b/Manual/Grind.lean
@@ -467,7 +467,7 @@ axiom q : Nat → Nat
 
 /-- info: h₁: [q #1] -/
 #guard_msgs (info) in
-@[grind? →] theorem h₁ (w : 7 = p (q x)) : p (x + 1) = q x := sorry
+@[grind? →] theorem h₁ (w : p (q x) = 7) : p (x + 1) = q x := sorry
 ```
 
 First, to understand the output we need to recall that the `#n` appearing in patterns are arguments of the theorem, numbered as de-Bruijn variables, i.e. in reverse order (so `#0` would be `w : p (q x) = 7`, while `#1` is the implicit argument `x`).


### PR DESCRIPTION
The text below the `example` refers to the hypothesis `p (q x) = 7` and to `7` as the "right-hand-side".  The proposed order also satisfies the "LHS is more complicated than the RHS" heuristic.
