### PR TITLE
fix: replace use of deleted GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
           sudo apt update && sudo apt install -y poppler-utils
 
       - name: Install deps for figures (TeX)
-        uses: teatimeguest/setup-texlive-action@v3
+        uses: zauguin/install-texlive@v4
         with:
-          version: 2024
+          texlive_version: 2024
           packages: |
             scheme-small
             latex-bin

--- a/.github/workflows/merge-main-nightly.yml
+++ b/.github/workflows/merge-main-nightly.yml
@@ -51,9 +51,9 @@ jobs:
           sudo apt update && sudo apt install -y poppler-utils
 
       - name: Install deps for figures (TeX)
-        uses: teatimeguest/setup-texlive-action@v3
+        uses: zauguin/install-texlive@v4
         with:
-          version: 2024
+          texlive_version: 2024
           packages: |
             scheme-small
             latex-bin

--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -17,9 +17,9 @@ jobs:
           sudo apt update && sudo apt install -y poppler-utils
 
       - name: Install deps for figures (TeX)
-        uses: teatimeguest/setup-texlive-action@v3
+        uses: zauguin/install-texlive@v4
         with:
-          version: 2024
+          texlive_version: 2024
           packages: |
             scheme-small
             latex-bin

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -41,9 +41,9 @@ jobs:
           ./deploy/prep.sh
 
       - name: Install deps for figures (TeX)
-        uses: teatimeguest/setup-texlive-action@v3
+        uses: zauguin/install-texlive@v4
         with:
-          version: 2024
+          texlive_version: 2024
           packages: |
             scheme-small
             latex-bin

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -96,9 +96,9 @@ jobs:
         sudo apt update && sudo apt install -y poppler-utils
 
     - name: Install deps for figures (TeX)
-      uses: teatimeguest/setup-texlive-action@v3
+      uses: zauguin/install-texlive@v4
       with:
-        version: 2024
+        texlive_version: 2024
         packages: |
           scheme-small
           latex-bin


### PR DESCRIPTION
teatimeguest/setup-texlive-action (and the entire associated GH account) is now 404ing, so we need to use an alternative.
