### PR TITLE
fix: make printed page look somewhat decent

### DIFF
--- a/static/print.css
+++ b/static/print.css
@@ -19,6 +19,9 @@
     pre {
         white-space: pre-wrap;
     }
+    pre.hl.lean {
+        white-space: pre-wrap;
+    }
     .hl.lean.block {
         white-space: pre-wrap;
     }

--- a/static/print.css
+++ b/static/print.css
@@ -19,6 +19,9 @@
     pre {
         white-space: pre-wrap;
     }
+    .hl.lean.block {
+        white-space: pre-wrap;
+    }
 
     /* Fix look of footnotes */
     span.marginalia span.note {

--- a/static/print.css
+++ b/static/print.css
@@ -1,16 +1,46 @@
 @media print {
-    /* Get rid of frames emulation, which breaks printing */
-    .with-toc {
-        display: block;
-        height: unset;
-    }
-    .with-toc > * {
-        grid-area: unset;
-    }
-    .with-toc > header {
+    /* Remove header */
+    header {
         display: none;
     }
+    .with-toc {
+        margin-top: 0;
+    }
+
+    /* Remove nav bar */
+    .with-toc > main {
+        padding-left: 0;
+    }
     #toc {
+        display: none;
+    }
+
+    /* Fix scroll bars appearing in some code snippets */
+    pre {
+        white-space: pre-wrap;
+    }
+
+    /* Fix look of footnotes */
+    span.marginalia span.note {
+        float: none;
+        margin: 0 0 0 1ch;
+        padding: 0 .5ch 0 1.5ch;
+        border: 1px solid #98B2C0;
+        border-radius: .5rem;
+    }
+    span.marginalia .note::before {
+        content: "i";
+        width: 1rem;
+        height: 1rem;
+        top: .1rem;
+        left: -.5rem;
+        line-height: 1.1rem;
+        text-align: center;
+        border: 1px solid #98B2C0;
+        border-radius: 1rem;
+        background-color: #fff;
+    }
+    span.marginalia::after {
         display: none;
     }
 


### PR DESCRIPTION
The nav bar took up a lot of space even though it wasn't displayed. I also got rid of the header while I was there.

Some code snippets were printed with a scroll bar instead of wrapping them. Also, footnotes can't float in print note and just looked broken, so I redesigned them as in-line info boxes. They still look a little wonky, but they're a lot better than overlapping digits onto text.

These changes are the result of my experiments on zulip: [#new members > Printable form of language reference? @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Printable.20form.20of.20language.20reference.3F/near/527227988)

They should help with #434 if one uses a browser to convert the single-page manual to a PDF.