### PR TITLE
build: add Dockerfile for local build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    python3 \
+    poppler-utils \
+    texlive-luatex \
+    texlive-latex-extra \
+    texlive-pictures \
+    texlive-fonts-extra \
+    texlive-fonts-recommended \
+    fonts-inter \
+    fonts-texgyre \
+    fonts-font-awesome \
+    gcc \
+    build-essential \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y
+
+ENV PATH="/root/.elan/bin:${PATH}"
+
+WORKDIR /app
+COPY . .
+
+RUN lake exe generate-manual --depth 2
+
+EXPOSE 8880
+
+CMD ["python3", "server.py", "8880"]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ python3 ./server.py 8880 &
 
 Then open <http://localhost:8880> in your browser.
 
+## Building the Reference Manual Using Docker
+
+If you prefer to use Docker, you can build and run the reference manual without installing dependencies manually. Follow these steps:
+
+1. Build the Docker image:
+
+   ```bash
+   docker build -t reference-manual .
+   ```
+
+2. Run the Docker container:
+
+   ```bash
+   docker run -p 8880:8880 reference-manual
+   ```
+
+3. Open <http://localhost:8880> in your browser to view the reference manual.
+
 ## Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more information.


### PR DESCRIPTION
### Added Docker Support for Building the Reference Manual

This pull request introduces the following changes:

- **Added a Dockerfile**: Simplifies the setup process for building the reference manual locally.
- **Updated the README**: Includes instructions for building and running the manual using Docker.

### Motivation

These changes aim to make it easier for contributors and users to build the reference manual without needing to install dependencies manually. Docker provides a consistent and isolated environment for building the project.

### Changes

1. **Dockerfile**:
   - Configured to build the reference manual in a containerized environment.
   - Ensures all necessary dependencies are installed.
2. **README Updates**:
   - Added a section explaining how to use Docker to build and run the manual.

### Related Issue

This pull request is not associated with any existing issue.