### PR TITLE
feat: reintroduce `Subarray`-related references

### DIFF
--- a/Manual/BasicTypes/Array/Subarray.lean
+++ b/Manual/BasicTypes/Array/Subarray.lean
@@ -22,7 +22,7 @@ tag := "subarray"
 
 {docstring Subarray}
 
-{docstring Subarray.array}
+{docstring Subarray.toArray}
 
 {docstring Subarray.empty}
 
@@ -50,6 +50,8 @@ tag := "subarray"
 
 # Iteration
 
+{docstring Subarray.foldl}
+
 {docstring Subarray.foldlM}
 
 {docstring Subarray.foldr}
@@ -59,6 +61,8 @@ tag := "subarray"
 {docstring Subarray.forM}
 
 {docstring Subarray.forRevM}
+
+{docstring Subarray.forIn}
 
 # Element Predicates
 


### PR DESCRIPTION
This PR reintroduces the references to some `Subarray`-related functions that have been temporarily removed in a96c958 in order to fix the reference manual build. In the meantime, the underlying problems have been resolved in https://github.com/leanprover/lean4/pull/9234.