### PR TITLE
chore: better LLVM flags

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -13,7 +13,9 @@ require verso from git "https://github.com/leanprover/verso.git"@"main"
 
 package "verso-manual" where
   -- building the C code cost much more than the optimizations save
-  moreLeancArgs := #["-O0"]
+  -- In particular, the Localizer pass of LLVM takes tons of time (ca 90% for many chapters) and these flags disable it
+  -- This is a circa 20% overall speedup (build and execute) at the time of writing
+  moreLeancArgs := #["-O0", "-mllvm", "-fast-isel", "-mllvm", "-fast-isel-abort=0"]
   -- work around clang emitting invalid linker optimization hints that lld rejects
   moreLinkArgs :=
     if System.Platform.isOSX then


### PR DESCRIPTION
LLVM is spending tons of time in the Localizer pass. These flags disable it, and the overall build-and-execute time on one machine went from 237s to 185s.
