### PR TITLE
feat: add `toTex` support for `Manual.keywordOf`

### DIFF
--- a/Manual/Meta/Syntax.lean
+++ b/Manual/Meta/Syntax.lean
@@ -125,10 +125,7 @@ def keywordOf : RoleExpander
 def keywordOf.descr : InlineDescr where
   traverse _ _ _ := do
     pure none
-  toTeX :=
-    some <| fun goI _id _ content => do
-      pure <| .seq <| ← content.mapM fun b => do
-        pure <| .seq #[← goI b]
+  toTeX := some fun goI _ _ content => content.mapM goI
   toHtml :=
     open Verso.Output Html in
     some <| fun goI _ info content => do

--- a/Manual/Meta/Syntax.lean
+++ b/Manual/Meta/Syntax.lean
@@ -125,7 +125,10 @@ def keywordOf : RoleExpander
 def keywordOf.descr : InlineDescr where
   traverse _ _ _ := do
     pure none
-  toTeX := none
+  toTeX :=
+    some <| fun go _id _ content => do
+      pure <| .seq <| ← content.mapM fun b => do
+        pure <| .seq #[← go b, .raw "\n"]
   toHtml :=
     open Verso.Output Html in
     some <| fun goI _ info content => do

--- a/Manual/Meta/Syntax.lean
+++ b/Manual/Meta/Syntax.lean
@@ -126,9 +126,9 @@ def keywordOf.descr : InlineDescr where
   traverse _ _ _ := do
     pure none
   toTeX :=
-    some <| fun go _id _ content => do
+    some <| fun goI _id _ content => do
       pure <| .seq <| ← content.mapM fun b => do
-        pure <| .seq #[← go b, .raw "\n"]
+        pure <| .seq #[← goI b]
   toHtml :=
     open Verso.Output Html in
     some <| fun goI _ info content => do


### PR DESCRIPTION
This PR adds TeX rendering support for `Manual.keywordOf`.

Relates to https://github.com/leanprover/reference-manual/issues/434
