### PR TITLE
fix: make the lake cache more suspicious

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -86,8 +86,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('lakefile.lean') }}-${{ github.sha }}
             ${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('lakefile.lean') }}
-            ${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-
-            ${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-
 
       - name: Run build script build.sh
         run: |


### PR DESCRIPTION
Currently, if we change something in Verso that does not change an actual .lean file (for instance, changing a string included via `include_str`, we'll restore a lake cache that will fail to trigger recompilation, fail to reevaluate the `include_str`, and therefore will not include the updated string).

This actually happened with [this commit which was an attempted bump of v4.24.0](https://github.com/leanprover/reference-manual/commit/bdb73c25bcadace4e5f279c818ab23d76e6a5ce7).

By fully recreating `.lake` if either the lake manifest or lakefile changes, we're still subject to this problem if we have an `include_str` in the reference-manual repository, but we won't fall to it in the `verso` repository. Possibly we should go further and insist that it be entirely unchanged?