### PR TITLE
fix: repair many examples in manual to run in isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
             rm parse_times.py
           else
             echo "No build log found" >> $GITHUB_STEP_SUMMARY
-          fi            
+          fi
 
       - name: Save cache for .lake
         uses: actions/cache/save@v4
@@ -148,6 +148,10 @@ jobs:
         if: github.event_name == 'release'
         run: |
           lake --quiet exe generate-manual --depth 2 --with-word-count "words.txt" --verbose --without-html-single
+
+      - name: Check Manual Examples are Isolated
+        run: |
+          scripts/check-examples-isolated.sh
 
       - name: Generate proofreading HTML
         if: github.event_name == 'pull_request'
@@ -380,4 +384,3 @@ jobs:
         run: |
           cd _out/html-multi/-verso-search
           tsc --noEmit -p jsconfig.json
-

--- a/Manual/Axioms.lean
+++ b/Manual/Axioms.lean
@@ -272,8 +272,8 @@ Consider the following three constants:
 
 ```lean
 def addThree (n : Nat) : Nat := 1 + n + 2
-theorem excludedMiddle (P : Prop) : P ∨ ¬ P := Classical.em P
-theorem simpleEquality (P : Prop) : (P ∨ False) = P := or_false P
+theorem excluded_middle (P : Prop) : P ∨ ¬ P := Classical.em P
+theorem simple_equality (P : Prop) : (P ∨ False) = P := or_false P
 ```
 
 Regular functions like {lean}`addThree` that we might want to actually evaluation typically do not depend on any axioms:
@@ -288,35 +288,40 @@ Regular functions like {lean}`addThree` that we might want to actually evaluatio
 The excluded middle theorem is only true if we use classical reasoning, so the foundation for classical reasoning shows up alongside other axioms:
 
 ```lean (name := printAxEx1)
-#print axioms excludedMiddle
+#print axioms excluded_middle
 ```
 ```leanOutput printAxEx1
-'excludedMiddle' depends on axioms: [propext, Classical.choice, Quot.sound]
+'excluded_middle' depends on axioms: [propext, Classical.choice, Quot.sound]
 ```
 
 Finally, the idea that two equivalent propositions are equal directly relies on {tech}[propositional extensionality].
 
 ```lean (name := printAxEx3)
-#print axioms simpleEquality
+#print axioms simple_equality
 ```
 ```leanOutput printAxEx3
-'simpleEquality' depends on axioms: [propext]
+'simple_equality' depends on axioms: [propext]
 ```
 :::
 
 :::example "Using {keywordOf Lean.Parser.Command.printAxioms}`#print axioms` with {keywordOf Lean.guardMsgsCmd}`#guard_msgs`"
 
-You can use {keywordOf Lean.Parser.Command.printAxioms}`#print axioms` together with {keywordOf Lean.guardMsgsCmd}`#guard_msgs` to ensure that updates to libraries from other projects cannot silently introduce unwanted dependencies on axioms.
+You can use {keywordOf Lean.Parser.Command.printAxioms}`#print axioms`
+together with {keywordOf Lean.guardMsgsCmd}`#guard_msgs` to ensure
+that updates to libraries from other projects cannot silently
+introduce unwanted dependencies on axioms.
 
-Perhaps you are worried that some future update to {lean}`or_false` in the previous example's {lean}`simpleEquality` proof might quietly introduce a new axiom dependency.
-You can guard against this by writing a command that will fail if {lean}`simpleEquality` uses any axioms besides {lean}`propext`:
+For example, if the proof of {name}`double_neg_elim` below changed in such a way that it used more
+axioms than those listed, then the {keywordOf Lean.guardMsgsCmd}`#guard_msgs` would report an error.
 
 ```lean
-/--
-info: 'simpleEquality' depends on axioms: [propext]
--/
+theorem double_neg_elim (P : Prop) : (¬ ¬ P) = P :=
+  propext Classical.not_not
+
+/-- info: 'double_neg_elim' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
-#print axioms simpleEquality
+#print axioms double_neg_elim
+
 ```
 :::
 

--- a/Manual/BasicTypes/BitVec.lean
+++ b/Manual/BasicTypes/BitVec.lean
@@ -170,6 +170,10 @@ The resulting proofs rely only on the axiom {name}`Lean.ofReduceBool`; the exter
 
 :::example "Popcount"
 
+```imports
+import Std.Tactic.BVDecide
+```
+
 The function {lean}`popcount` returns the number of set bits in a bitvector.
 It can be implemented as a 32-iteration loop that tests each bit, incrementing a counter if the bit is set:
 

--- a/Manual/BasicTypes/Maps.lean
+++ b/Manual/BasicTypes/Maps.lean
@@ -7,6 +7,7 @@ Author: David Thrane Christiansen
 import VersoManual
 
 import Manual.Meta
+import Manual.Meta.ImportsBlock
 
 import Manual.BasicTypes.Maps.TreeSet
 import Manual.BasicTypes.Maps.TreeMap
@@ -176,6 +177,10 @@ A nested inductive type that occurs inside a map or set should be defined in thr
 
 :::example "Nested Inductive Types with `Std.HashMap`"
 
+```imports
+import Std
+```
+
 This example requires that `Std.Data.HashMap.RawLemmas` is imported.
 To keep the code shorter, the `Std` namespace is opened:
 ```lean
@@ -304,6 +309,10 @@ In particular, when possible, operations such as {name Std.HashMap.alter}`alter`
 These operations avoid creating a second reference to the value during modification.
 
 :::example "Modifying Values in Maps"
+
+```imports
+import Std
+```
 
 ```lean
 open Std

--- a/Manual/BasicTypes/Option.lean
+++ b/Manual/BasicTypes/Option.lean
@@ -38,6 +38,10 @@ The {lean}`Option` API makes frequent use of this perspective.
 
 :::example "Options as Nullability"
 
+```imports
+import Std
+```
+
 ```lean -show
 open Std (HashMap)
 variable {Coll} [BEq α] [Hashable α] (a : α) (b : β) {xs : Coll} [GetElem Coll α β fun _ _ => True] {i : α} {m : HashMap α β}
@@ -63,6 +67,10 @@ If {lean}`m`﻿` : `﻿{lean}`HashMap α β` and {lean}`a`﻿` : `﻿{lean}`α`,
 In many programming languages, it is important to remember to check for the null value.
 When using {name}`Option`, the type system requires these checks in the right places: {lean}`Option α` and {lean}`α` are not the same type, and converting from one to the other requires handling the case of {lean  (type := "Option α")}`none`.
 This can be done via helpers such as {name}`Option.getD`, or with pattern matching.
+
+```imports
+import Std
+```
 
 ```lean
 def postalCodes : Std.HashMap Nat String :=

--- a/Manual/Classes/DerivingHandlers.lean
+++ b/Manual/Classes/DerivingHandlers.lean
@@ -84,6 +84,11 @@ Lean includes deriving handlers for the following classes:
 
 ::::keepEnv
 :::example "Deriving Handlers"
+
+```imports
+import Lean.Elab
+```
+
 Instances of the {name}`IsEnum` class demonstrate that a type is a finite enumeration by providing a bijection between the type and a suitably-sized {name}`Fin`:
 ```lean
 class IsEnum (α : Type) where

--- a/Manual/Coercions.lean
+++ b/Manual/Coercions.lean
@@ -168,7 +168,7 @@ def Bin.ofNat (n : Nat) : Bin :=
   | n + 1 => (Bin.ofNat n).succ
 ```
 
-```lean -show
+```lean -show -keep
 --- Internal tests
 /-- info: [0, 1, 10, 11, 100, 101, 110, 111, 1000] -/
 #check_msgs in
@@ -182,7 +182,8 @@ def Bin.ofNat (n : Nat) : Bin :=
   Bin.done.succ.succ.succ.succ.succ.succ,
   Bin.done.succ.succ.succ.succ.succ.succ.succ,
   Bin.done.succ.succ.succ.succ.succ.succ.succ.succ]
-
+```
+```lean -show
 def Bin.toNat : Bin → Nat
   | .done => 0
   | .zero b => 2 * b.toNat
@@ -206,12 +207,13 @@ theorem Bin.ofNat_toNat_eq {n : Nat} : (Bin.ofNat n).toNat = n := by
 
 
 Even if {lean}`Bin.ofNat` is registered as a coercion, natural number literals cannot be used for {lean}`Bin`:
-```lean (name := nineFail) +error
+```lean
 attribute [coe] Bin.ofNat
 
 instance : Coe Nat Bin where
   coe := Bin.ofNat
-
+```
+``` lean (name := nineFail) +error
 #eval (9 : Bin)
 ```
 ```leanOutput nineFail

--- a/Manual/Grind.lean
+++ b/Manual/Grind.lean
@@ -104,6 +104,9 @@ example (a b c : Nat) (h₁ : a = b) (h₂ : b = c) :
 
 This proof uses {tactic}`grind`'s commutative ring solver.
 
+```lean -show
+open Lean.Grind
+```
 ```lean
 example [CommRing α] [NoNatZeroDivisors α] (a b c : α) :
     a + b + c = 3 →

--- a/Manual/Grind/Algebra.lean
+++ b/Manual/Grind/Algebra.lean
@@ -37,6 +37,9 @@ open Lean Grind
 ```
 
 :::example "Commutative Rings" (open := true)
+```lean -show
+open Lean.Grind
+```
 ```lean
 example [CommRing α] (x : α) : (x + 1) * (x - 1) = x ^ 2 - 1 := by
   grind
@@ -45,6 +48,9 @@ example [CommRing α] (x : α) : (x + 1) * (x - 1) = x ^ 2 - 1 := by
 :::example "Ring Characteristics" (open := true)
 The solver “knows” that `16*16 = 0` because the [ring characteristic](https://en.wikipedia.org/wiki/Characteristic_%28algebra%29) (that is, the minimum number of copies of the multiplicative identity that sum to the additive identity) is `256`, which is provided by the {name}`IsCharP` instance.
 
+```lean -show
+open Lean.Grind
+```
 ```lean
 example [CommRing α] [IsCharP α 256] (x : α) :
     (x + 16)*(x - 16) = x^2 := by
@@ -53,6 +59,9 @@ example [CommRing α] [IsCharP α 256] (x : α) :
 :::
 
 :::example "Standard Library Types" (open := true)
+```lean -show
+open Lean.Grind
+```
 Types in the standard library are supported by the solver out of the box.
 `UInt8` is a commutative ring with characteristic `256`, and thus has instances of {inst}`CommRing UInt8` and {inst}`IsCharP UInt8 256`.
 ```lean
@@ -62,6 +71,9 @@ example (x : UInt8) : (x + 16) * (x - 16) = x ^ 2 := by
 :::
 
 :::example "More Commutative Ring Proofs" (open := true)
+```lean -show
+open Lean.Grind
+```
 The axioms of a commutative ring are sufficient to prove these statements.
 
 ```lean
@@ -83,6 +95,9 @@ example [CommRing α] (x y : α) :
 :::
 
 :::example "Characteristic Zero" (open := true)
+```lean -show
+open Lean.Grind
+```
 `ring` proves that `a + 1 = 2 + a` is unsatisfiable because the characteristic is known to be 0.
 
 ```lean
@@ -93,6 +108,9 @@ example [CommRing α] [IsCharP α 0] (a : α) :
 :::
 
 :::example "Inferred Characteristic" (open := true)
+```lean -show
+open Lean.Grind
+```
 Even when the characteristic is not initially known, when `grind` discovers that `n = 0` for some numeral `n`, it makes inferences about the characteristic:
 ```lean
 example [CommRing α] (a b c : α)
@@ -163,7 +181,9 @@ It also rewrites every disequality `p ≠ 0` as the equality `p * p⁻¹ = 1`.
 :::
 
 ::::example "Fields and `grind`"
-
+```lean -show
+open Lean.Grind
+```
 This example requires its {name}`Field` instance:
 
 ```lean
@@ -198,6 +218,9 @@ For example, the polynomial `2 * x * y + 4 * z = 0` is simplified to `x * y + 2 
 It also used when processing disequalities.
 
 :::example "Using `NoNatZeroDivisors`"
+```lean -show
+open Lean.Grind
+```
 In this example, {tactic}`grind` relies on the {name}`NoNatZeroDivisors` instance to simplify the goal:
 ```lean
 example [CommRing α] [NoNatZeroDivisors α] (a b : α) :
@@ -310,6 +333,9 @@ example (x y : Nat) :
 Gröbner basis computation can be very expensive. You can limit the number of steps performed by the `ring` solver using the option `grind (ringSteps := <num>)`
 
 :::example "Limiting `ring` Steps"
+```lean -show
+open Lean.Grind
+```
 This example cannot be solved by performing at most 100 steps:
 ```lean +error (name := ring100)
 example [CommRing α] [IsCharP α 0] (d t c : α) (d_inv PSO3_inv : α) :

--- a/Manual/Grind/Linarith.lean
+++ b/Manual/Grind/Linarith.lean
@@ -38,6 +38,12 @@ It can be disabled using the option `grind -linarith`.
 
 
 :::example "Goals Decided by `linarith`" (open := true)
+```imports
+import Std
+```
+```lean -show
+open Lean.Grind
+```
 All of these examples rely on instances of the following ordering notation and `linarith` classes:
 ```lean
 variable [LE α] [LT α] [Std.LawfulOrderLT α]  [Std.IsLinearOrder α]
@@ -69,7 +75,12 @@ example {a b c d e : α} :
 :::
 
 :::example "Commutative Ring Goals Decided by `linarith`" (open := true)
-
+```imports
+import Std
+```
+```lean -show
+open Lean.Grind
+```
 For types that are commmutative rings (that is, types in which the multiplication operator is commutative) with {name}`CommRing` instances, `linarith` has more capabilities.
 
 ```lean

--- a/Manual/Interaction.lean
+++ b/Manual/Interaction.lean
@@ -311,6 +311,9 @@ Lists all axioms that the constant transitively relies on. See {ref "print-axiom
 :::
 
 :::example "Printing Axioms"
+```imports
+import Std.Tactic.BVDecide
+```
 
 These two functions each swap the elements in a pair of bitvectors:
 

--- a/Manual/Interaction/FormatRepr.lean
+++ b/Manual/Interaction/FormatRepr.lean
@@ -93,6 +93,9 @@ The most important {name Std.Format}`Format` operations are:
 ::::
 
 :::example "Widths and Newlines"
+```imports
+import Std
+```
 ```lean
 open Std Format
 ```
@@ -112,7 +115,7 @@ def lst : Format := parenSeq nums
 where nums := [1, 2, 3, 4, 5].map (text s!"{·}")
 ```
 
-```lean -show
+```lean -show -keep
 -- check statement in next paragraph
 /-- info: 120 -/
 #check_msgs in
@@ -563,7 +566,7 @@ In some cases, however, it's necessary to write an instance by hand:
 * The derived {name}`Repr` instance for structures uses {tech}[structure instance] notation.
   A hand-written instance can use the constructor's name explicitly or use {tech}[anonymous constructor syntax].
 
-```lean -show
+```lean -show -keep
 /-- info: Std.HashSet.ofList [0, 3, 5] -/
 #check_msgs in
 #eval IO.println <| repr (({} : Std.HashSet Nat).insert 3 |>.insert 5 |>.insert 0)
@@ -754,7 +757,7 @@ protected def AddExpr.reprPrec : AddExpr → Nat → Std.Format
 instance : Repr AddExpr := ⟨AddExpr.reprPrec⟩
 ```
 
-```lean -show
+```lean -show -keep
 -- Test that the guidelines provided for infix operators match Lean's own pretty printer
 /--
 info: 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 1 + 2 + 3 + 4 + 5 + 6 + 7 +

--- a/Manual/Language/InductiveTypes/Structures.lean
+++ b/Manual/Language/InductiveTypes/Structures.lean
@@ -163,6 +163,9 @@ Its constructor is named {name}`Palindrome.ofString`, rather than `Palindrome.mk
 :::
 
 ::: example "Modifiers on structure constructor"
+```imports
+import Std
+```
 The structure {lean}`NatStringBimap` maintains a finite bijection between natural numbers and strings.
 It consists of a pair of maps, such that the keys each occur as values exactly once in the other map.
 Because the constructor is private, code outside the defining module can't construct new instances and must use the provided API, which maintains the invariants of the type.

--- a/Manual/Meta/ImportsBlock.lean
+++ b/Manual/Meta/ImportsBlock.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jason Reed
+-/
+
+import Verso
+
+open Verso Doc Elab
+
+namespace Manual
+
+/--
+Defines a code block expander for specifying imports for lean code examples.
+It elaborates to nothing normally, but it is useful for constructing examples
+as self-contained code for copy-paste or linking to the live sandbox website.
+-/
+@[code_block_expander imports]
+def imports : CodeBlockExpander
+  | _args, _str => do
+    return #[]

--- a/Manual/NotationsMacros.lean
+++ b/Manual/NotationsMacros.lean
@@ -617,6 +617,9 @@ The optional suffix `?` in syntax and splices correspond with each other.
 
 ::::keepEnv
 :::example "Suffixed Splices"
+```imports
+import Lean.Elab
+```
 ```lean -show
 open Lean
 open Lean.Elab.Command (CommandElabM)
@@ -691,6 +694,9 @@ macro_rules
 
 ::::keepEnv
 :::example "Optional Splices"
+```imports
+import Lean.Elab
+```
 The following syntax declaration optionally matches a term between two tokens.
 The parentheses around the nested `term` are needed because `term?` is a valid identifier.
 ```lean -show
@@ -916,6 +922,9 @@ some 4
 
 ::::keepEnv
 :::example "Scoped Macros"
+```lean -show
+open Lean
+```
 Scoped macro rules are active only in their namespace.
 When the namespace `ConfusingNumbers` is open, numeric literals will be assigned an incorrect meaning.
 ```lean
@@ -970,7 +979,6 @@ First, the rules in a {keywordOf Lean.Parser.Command.macro_rules}`macro_rules` a
 Additionally, if an earlier rule in the macro throws the {name Lean.Macro.Exception.unsupportedSyntax}`unsupportedSyntax` exception, then the later rules are not tried; if they were instead in separate {keywordOf Lean.Parser.Command.macro_rules}`macro_rules` commands, then they would be attempted.
 
 ::::example "One vs. Two Sets of Macro Rules"
-
 ```lean -show
 open Lean.Macro
 ```

--- a/Manual/NotationsMacros/Elab.lean
+++ b/Manual/NotationsMacros/Elab.lean
@@ -91,6 +91,12 @@ A command elaborator has type {name}`CommandElab`, which is an abbreviation for 
 Command elaborators may be implicitly defined using {keywordOf Lean.Parser.Command.elab_rules}`elab_rules`, or explicitly by defining a function and applying the {attr}`command_elab` attribute.
 
 :::example "Querying the Environment"
+```imports
+import Lean.Elab
+```
+```lean -show
+open Lean
+```
 
 A command elaborator can be used to query the environment to discover how many constants have a given name.
 This example uses {name}`getEnv` from the {name}`MonadEnv` class to get the current environment.
@@ -137,6 +143,12 @@ The optional {lean}`Expr` parameter is the type expected for the term being elab
 Like command elaborators, term elaborators may be implicitly defined using {keywordOf Lean.Parser.Command.elab_rules}`elab_rules`, or explicitly by defining a function and applying the {attr}`term_elab` attribute.
 
 :::example "Avoiding a Type"
+```imports
+import Lean.Elab
+```
+```lean -show
+open Lean Elab Term
+```
 
 This examples demonstrates an elaborator for syntax that is the opposite of a type ascription.
 The provided term may have any type _other_ than the one indicated, and metavariables are solved pessimistically.
@@ -193,6 +205,12 @@ Got unwanted type String
 :::
 
 :::example "Using Any Local Variable"
+```imports
+import Lean.Elab
+```
+```lean -show
+open Lean
+```
 
 Term elaborators have access to the expected type and to the local context.
 This can be used to create a term analogue of the {tactic}`assumption` tactic.

--- a/Manual/NotationsMacros/SyntaxDef.lean
+++ b/Manual/NotationsMacros/SyntaxDef.lean
@@ -191,6 +191,13 @@ There are three primary ways to inspect {lean}`Syntax` values:
 
 ::::keepEnv
 :::example "Representing Syntax as Constructors"
+```imports
+import Lean.Elab
+```
+```lean -show
+open Lean
+```
+
 The {name}`Repr` instance's representation of syntax can be inspected by quoting it in the context of {keywordOf Lean.Parser.Command.eval}`#eval`, which can run actions in the command elaboration monad {name Lean.Elab.Command.CommandElabM}`CommandElabM`.
 To reduce the size of the example output, the helper {lean}`removeSourceInfo` is used to remove source information prior to display.
 ```lean
@@ -260,6 +267,12 @@ The {name}`ToString` instance represents the constructors of {name}`Syntax` as f
    Otherwise, the node is represented by its kind followed by its child nodes, both surrounded by parentheses.
 
 :::example "Syntax as Strings"
+```imports
+import Lean.Elab
+```
+```lean -show
+open Lean
+```
 The string representation of syntax can be inspected by quoting it in the context of {keywordOf Lean.Parser.Command.eval}`#eval`, which can run actions in the command elaboration monad {name Lean.Elab.Command.CommandElabM}`CommandElabM`.
 
 ```lean (name := toStringStx1)
@@ -290,6 +303,9 @@ However, {name}`ppTerm` can be explicitly invoked if needed.
 
 ::::keepEnv
 :::example "Pretty-Printed Syntax"
+```imports
+import Lean.Elab
+```
 ```lean -show
 open Lean Elab Command
 ```

--- a/Manual/RecursiveDefs/Structural/CourseOfValuesExample.lean
+++ b/Manual/RecursiveDefs/Structural/CourseOfValuesExample.lean
@@ -130,7 +130,7 @@ def Tree.brecOn' {α : Type u}
   (t.brecOnTable (motive := motive) step).1
 ```
 
-```lean -show
+```lean -show -keep
 -- Proving the above-claimed equivalence is too time consuming, but evaluating a few examples will at least catch silly mistakes!
 
 /--

--- a/Manual/Tactics/Custom.lean
+++ b/Manual/Tactics/Custom.lean
@@ -90,10 +90,11 @@ This is used to make a number of Lean's built-in tactics extensible—new behavi
 
 The {tactic}`trivial`, which is used by many other tactics to quickly dispatch subgoals that are not worth bothering the user with, is designed to be extended through new macro expansions.
 Lean's default {lean}`trivial` can't solve {lean}`IsEmpty []` goals:
-```lean +error
+```lean
 def IsEmpty (xs : List α) : Prop :=
   ¬ xs ≠ []
-
+```
+```lean +error
 example (α : Type u) : IsEmpty (α := α) [] := by trivial
 ```
 

--- a/Manual/Terms.lean
+++ b/Manual/Terms.lean
@@ -605,6 +605,9 @@ Finally, instance synthesis is invoked and as many metavariables as possible are
 
 ::::keepEnv
 :::example "Named Arguments"
+```lean -show
+set_option linter.unusedVariables false
+```
 The {keywordOf Lean.Parser.Command.check}`#check` command can be used to inspect the arguments that were inserted for a function call.
 
 The function {name}`sum3` takes three explicit {lean}`Nat` parameters, named `x`, `y`, and `z`.

--- a/Manual/Types.lean
+++ b/Manual/Types.lean
@@ -382,7 +382,7 @@ partial def count [Monad m] (p : α → Bool) (act : m α) : m Nat := do
     return 0
 ```
 
-```lean -show
+```lean -show -keep
 /-- info: Nat : Type -/
 #check_msgs in
 #check Nat

--- a/scripts/check-examples-isolated.sh
+++ b/scripts/check-examples-isolated.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+successes=0
+failures=0
+
+while IFS= read -r file; do
+    output=$(lean "$file" 2>&1)
+    status=$?
+    if [ $status -ne 0 ]; then
+        echo "=== Failed: $file"
+        echo "$output"
+        ((failures++))
+    else
+        echo "=== Succeeded: $file"
+        ((successes++))
+    fi
+done < <(find _out/extracted-examples -name '*lean')
+
+echo
+echo "Summary:"
+echo "  Succeeded: $successes"
+echo "  Failed:    $failures"
+
+if [ $failures -ne 0 ]; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
There are a few dozen `:::example` directives in the manual that won't run correctly if you copy and paste them into https://live.lean-lang.org/ . Fix them all, and include a CI check to ensure that they are all fixes. A sampling of reasons include:
- `#check_decl` is defined in reference manual but not available in live
- `import`s of `Lean` or `Std` are missing
- `open`s prior to the `:::example` are necessary
- important definitions are in `+error` blocks and needed to be hoisted


Based on top of https://github.com/leanprover/reference-manual/pull/609 .
Progress towards https://github.com/leanprover/verso/issues/569 .