### PR TITLE
fix: update FFI example links

### DIFF
--- a/Manual/Runtime.lean
+++ b/Manual/Runtime.lean
@@ -356,7 +356,7 @@ Exports a Lean constant with the unmangled symbol name `sym`.
 :::
 
 
-For simple examples of how to call foreign code from Lean and vice versa, see [the FFI](https://github.com/leanprover/lean4/blob/master/src/lake/examples/ffi) and [reverse FFI](https://github.com/leanprover/lean4/blob/master/src/lake/examples/reverse-ffi) examples in the Lean source repository.
+For simple examples of how to call foreign code from Lean and vice versa, see [the FFI](https://github.com/leanprover/lean4/tree/master/tests/lake/examples/ffi) and [reverse FFI](https://github.com/leanprover/lean4/tree/master/tests/lake/examples/reverse-ffi) examples in the Lean source repository.
 
 ## The Lean ABI
 


### PR DESCRIPTION
Noticed that the FFI examples were moved in [this commit](https://github.com/leanprover/lean4/commit/aa3d409eb61678f596054c4df4dcf6f2c5369244), so just updating that link in the docs. 