### PR TITLE
chore: enable nightly-with-manual script

### DIFF
--- a/.github/workflows/nightly-with-manual.yml
+++ b/.github/workflows/nightly-with-manual.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'nightly-testing-*'
   workflow_dispatch:
+  workflow_call:
+  schedule:
+    - cron: '0 14 * * *'  # 2PM UTC
+    - cron: '0 22 * * *'  # 10PM UTC
 
 jobs:
   build:
@@ -54,5 +58,5 @@ jobs:
           git fetch nightly --tags
           # Note: old jobs may run out of order, but it is safe to merge an older `nightly-YYYY-MM-DD`.
           git merge "nightly-${NIGHTLY}" --strategy-option ours --allow-unrelated-histories || true
-          git push --dry-run origin
+          git push origin
 

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -74,6 +74,8 @@ jobs:
     if: needs.check-update.outputs.update-needed == 'true'
     permissions:
       contents: write
+    outputs:
+      changes-pushed: ${{ steps.commit.outputs.changes-pushed }}
 
     steps:
     - name: Checkout repository
@@ -146,6 +148,7 @@ jobs:
         lake exe generate-manual --depth 2 --without-html-single
 
     - name: Commit and push changes
+      id: commit
       run: |
         git add lean-toolchain
         git commit -m "chore: bump to nightly ${{ needs.check-update.outputs.latest-version }}"
@@ -156,4 +159,10 @@ jobs:
             version=${toolchain#leanprover/lean4:nightly-}
             git tag "nightly-testing-$version"
             git push origin "nightly-testing-$version"
+            echo "changes-pushed=true" >> $GITHUB_OUTPUT
         fi
+
+  trigger-nightly-with-manual:
+    needs: test-and-update
+    if: needs.test-and-update.outputs.changes-pushed == 'true'
+    uses: ./.github/workflows/nightly-with-manual.yml


### PR DESCRIPTION
Also adds a cron setup so it will run even if GH restrictions on scripts triggering scripts get in the way, and has update-nightly invoke it explicitly at the end.

