### PR TITLE
fix: inherit secrets when updating nightly tag

### DIFF
--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -166,3 +166,4 @@ jobs:
     needs: test-and-update
     if: needs.test-and-update.outputs.changes-pushed == 'true'
     uses: ./.github/workflows/nightly-with-manual.yml
+    secrets: inherit


### PR DESCRIPTION
Otherwise, it fails to check out the `lean4` repository.