### PR TITLE
fix: update FFI docs based on changes upstream in ffi.md

### DIFF
--- a/Manual/Language/InductiveTypes.lean
+++ b/Manual/Language/InductiveTypes.lean
@@ -469,7 +469,7 @@ The memory order of the fields is derived from the types and order of the fields
 * Fields of type {lean}`USize`
 * Other scalar fields, in decreasing order by size
 
-Within each group the fields are ordered in declaration order. *Warning*: Trivial wrapper types still count toward a field being treated as non-scalar for this purpose.
+Within each group the fields are ordered in declaration order. *Warning*: Trivial wrapper types count as their underlying wrapped type for this purpose.
 
 * To access fields of the first kind, use {c}`lean_ctor_get(val, i)` to get the `i`th non-scalar field.
 * To access {lean}`USize` fields, use {c}`lean_ctor_get_usize(val, n+i)` to get the {c}`i`th `USize` field and {c}`n` is the total number of fields of the first kind.
@@ -483,34 +483,34 @@ structure S where
   ptr_1 : Array Nat
   usize_1 : USize
   sc64_1 : UInt64
-  -- wrappers don't count as scalars:
-  ptr_2 : { x : UInt64 // x > 0 }
-  sc64_2 : Float -- `Float` is 64 bit
+   -- Wrappers of scalars count as scalars:
+  sc64_2 : { x : UInt64 // x > 0 }
+  sc64_3 : Float -- `Float` is 64 bit
   sc8_1 : Bool
   sc16_1 : UInt16
   sc8_2 : UInt8
-  sc64_3 : UInt64
+  sc64_4 : UInt64
   usize_2 : USize
-  -- trivial wrapper around `UInt32`
-  ptr_3 : Char
-  sc32_1 : UInt32
+  -- Trivial wrapper around `UInt32`
+  sc32_1 : Char
+  sc32_2 : UInt32
   sc16_2 : UInt16
 ```
 would get re-sorted into the following memory order:
 
 * {name}`S.ptr_1` - {c}`lean_ctor_get(val, 0)`
-* {name}`S.ptr_2` - {c}`lean_ctor_get(val, 1)`
-* {name}`S.ptr_3` - {c}`lean_ctor_get(val, 2)`
-* {name}`S.usize_1` - {c}`lean_ctor_get_usize(val, 3)`
-* {name}`S.usize_2` - {c}`lean_ctor_get_usize(val, 4)`
-* {name}`S.sc64_1` - {c}`lean_ctor_get_uint64(val, sizeof(void*)*5)`
-* {name}`S.sc64_2` - {c}`lean_ctor_get_float(val, sizeof(void*)*5 + 8)`
-* {name}`S.sc64_3` - {c}`lean_ctor_get_uint64(val, sizeof(void*)*5 + 16)`
-* {name}`S.sc32_1` - {c}`lean_ctor_get_uint32(val, sizeof(void*)*5 + 24)`
-* {name}`S.sc16_1` - {c}`lean_ctor_get_uint16(val, sizeof(void*)*5 + 28)`
-* {name}`S.sc16_2` - {c}`lean_ctor_get_uint16(val, sizeof(void*)*5 + 30)`
-* {name}`S.sc8_1` - {c}`lean_ctor_get_uint8(val, sizeof(void*)*5 + 32)`
-* {name}`S.sc8_2` - {c}`lean_ctor_get_uint8(val, sizeof(void*)*5 + 33)`
+* {name}`S.usize_1` - {c}`lean_ctor_get_usize(val, 1)`
+* {name}`S.usize_2` - {c}`lean_ctor_get_usize(val, 2)`
+* {name}`S.sc64_1` - {c}`lean_ctor_get_uint64(val, sizeof(void*)*3)`
+* {name}`S.sc64_2` - {c}`lean_ctor_get_uint64(val, sizeof(void*)*3 + 8)`
+* {name}`S.sc64_3` - {c}`lean_ctor_get_float(val, sizeof(void*)*3 + 16)`
+* {name}`S.sc64_4` - {c}`lean_ctor_get_uint64(val, sizeof(void*)*3 + 24)`
+* {name}`S.sc32_1` - {c}`lean_ctor_get_uint32(val, sizeof(void*)*3 + 32)`
+* {name}`S.sc32_2` - {c}`lean_ctor_get_uint32(val, sizeof(void*)*3 + 36)`
+* {name}`S.sc16_1` - {c}`lean_ctor_get_uint16(val, sizeof(void*)*3 + 40)`
+* {name}`S.sc16_2` - {c}`lean_ctor_get_uint16(val, sizeof(void*)*3 + 42)`
+* {name}`S.sc8_1` - {c}`lean_ctor_get_uint8(val, sizeof(void*)*3 + 44)`
+* {name}`S.sc8_2` - {c}`lean_ctor_get_uint8(val, sizeof(void*)*3 + 45)`
 
 ::::
 

--- a/Manual/Runtime.lean
+++ b/Manual/Runtime.lean
@@ -8,6 +8,7 @@ import VersoManual
 import Manual.Meta
 import Manual.Meta.LexedText
 import Manual.Papers
+import Std.Internal.Async.Process
 
 open Manual
 open Verso.Genre
@@ -458,39 +459,45 @@ For all other modules imported by `lean`, the initializer is run without `builti
 In other words, {attr}`init` functions are run if and only if their module is imported, regardless of whether they have native code available, while {attr}`builtin_init` functions are only run for native executable or plugins, regardless of whether their module is imported.
 The Lean compiler uses built-in initializers for purposes such as registering basic parsers that should be available even without importing their module, which is necessary for bootstrapping.
 
-The initializer for module `A.B` is called {c}`initialize_A_B` and will automatically initialize any imported modules.
-Module initializers are idempotent when run with the same `builtin` flag, but not thread-safe.
+The initializer for module `A.B` in a package `foo` is called {c}`initialize_foo_A_B`.
+For modules in the Lean core (e.g., {module}`Init.Prelude`), the initializer is called {c}`initialize_Init_Prelude`.
+Module initializers will automatically initialize any imported modules.
+They are also idempotent (when run with the same `builtin` flag), but not thread-safe.
+
+*Important for process-related functionality*: applications that use process-related functions from `libuv`, such as {name}`Std.Internal.IO.Process.getProcessTitle` and {name}`Std.Internal.IO.Process.setProcessTitle`, must call `lean_setup_args(argc, argv)` (which returns a potentially modified `argv` that must be used in place of the original) *before* calling `lean_initialize()` or `lean_initialize_runtime_module()`.
+This sets up process handling capabilities correctly, which is essential for certain system-level operations that Lean's runtime may depend on.
+
 Together with initialization of the Lean runtime, code like the following should be run exactly once before accessing any Lean declarations:
 ```c
 void lean_initialize_runtime_module();
 void lean_initialize();
-lean_object * initialize_A_B(uint8_t builtin, lean_object *);
-lean_object * initialize_C(uint8_t builtin, lean_object *);
+char ** lean_setup_args(int argc, char ** argv);
+
+lean_object * initialize_A_B(uint8_t builtin);
+lean_object * initialize_C(uint8_t builtin);
 ...
 
+argv = lean_setup_args(argc, argv); // if using process-related functionality
 lean_initialize_runtime_module();
-// Necessary (and replaces `lean_initialize_runtime_module`) for code that
-// (indirectly) accesses the `Lean` package:
+// necessary (and replaces `lean_initialize_runtime_module`) for code that (indirectly) accesses the `Lean` package:
 //lean_initialize();
 
 lean_object * res;
 // use same default as for Lean executables
 uint8_t builtin = 1;
-res = initialize_A_B(builtin, lean_io_mk_world());
+res = initialize_foo_A_B(builtin);
 if (lean_io_result_is_ok(res)) {
     lean_dec_ref(res);
 } else {
     lean_io_result_show_error(res);
     lean_dec(res);
-    // do not access Lean declarations if initialization failed
-    return ...;
+    return ...;  // do not access Lean declarations if initialization failed
 }
-res = initialize_C(builtin, lean_io_mk_world());
+res = initialize_bar_C(builtin);
 if (lean_io_result_is_ok(res)) {
 ...
 
-// Necessary for code that (indirectly) uses `Task`
-//lean_init_task_manager();
+//lean_init_task_manager();  // necessary for code that (indirectly) uses `Task`
 lean_io_mark_end_initialization();
 ```
 


### PR DESCRIPTION
ffi.md was updated in Lean, but not here. This PR incorporates the changes.

A corresponding Lean PR replaces ffi.md with a link to this reference manual: https://github.com/leanprover/lean4/pull/11737