### PR TITLE
fix: change 'def' to 'abbrev' in the abbrev section

### DIFF
--- a/Manual/Defs.lean
+++ b/Manual/Defs.lean
@@ -547,7 +547,7 @@ abbrev $_ $_ where
   $_*
 ```
 
-In {tech}[modules], the bodies of definitions defined with {keyword}`def` are exposed by default.
+In {tech}[modules], the bodies of definitions defined with {keyword}`abbrev` are exposed by default.
 :::
 
 


### PR DESCRIPTION
This PR changes `def` to `abbrev` in the section on the `abbrev` command.