### PR TITLE
fix: don't show a warning in tutorial code for mvcgen

### DIFF
--- a/Tutorial/VCGen.lean
+++ b/Tutorial/VCGen.lean
@@ -48,9 +48,12 @@ import Std.Data.HashSet
 ```imports
 import Std.Tactic.Do
 ```
+:::codeOnly
 ```lean
 set_option mvcgen.warning false
-
+```
+:::
+```lean
 open Std.Do
 ```
 


### PR DESCRIPTION
A warning was showing up in the downloadable tutorial code.