### PR TITLE
chore: only use -O0 for opt

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -14,9 +14,7 @@ require versowebcomponents from git "https://github.com/leanprover/verso-web-com
 
 package "verso-manual" where
   -- building the C code cost much more than the optimizations save
-  -- In particular, the Localizer pass of LLVM takes tons of time (ca 90% for many chapters) and these flags disable it
-  -- This is a circa 20% overall speedup (build and execute) at the time of writing
-  moreLeancArgs := #["-O0", "-mllvm", "-fast-isel", "-mllvm", "-fast-isel-abort=0"]
+  moreLeancArgs := #["-O0"]
   -- work around clang emitting invalid linker optimization hints that lld rejects
   moreLinkArgs :=
     if System.Platform.isOSX then


### PR DESCRIPTION
As long as we've been using Radar, the difference between our optimized opt-args and plain O0 has been negligible. Let's simplify.

# Some graphs

These graphs are messy because sometimes the manual version doesn't compile, but whenever the "success" line is high, this should be treated as a fair comparison:

[total benchmark time](https://radar.lean-lang.org/repos/verso/graph?m=radar/run/refman-o0//time&m=radar/run/refman//time&m=refman/compile//success&n=100&right=success&s=(^radar)|(%5C.total//))

<img width="883" height="590" alt="image" src="https://github.com/user-attachments/assets/a451f887-8c20-4d52-9a4b-03e2830d5a11" />

[c.o creation time](https://radar.lean-lang.org/repos/verso/graph?m=refman-no-opt-args/compile//success&m=refman-o0/build/.total//c.o+time&m=refman-o0/compile//success&m=refman/build/.total//c.o+time&m=refman/compile//success&n=100&right=success&s=(^radar)|(%5C.total//))

<img width="883" height="590" alt="image" src="https://github.com/user-attachments/assets/0ba1b3c1-98ca-4d82-8dc2-232c4b16a470" />

[wall clock build time](https://radar.lean-lang.org/repos/verso/graph?m=refman-o0/build/.total//wall+clock+time&m=refman/build/.total//wall+clock+time&m=refman/compile//success&n=100&right=success&s=(^radar)|(%5C.total//))

<img width="883" height="590" alt="image" src="https://github.com/user-attachments/assets/2c9e7cfb-19c2-4f1a-92bf-51588a332d25" />

----

compare this [to the difference between -O0 and no-opt-args for c.o time over the same period](https://radar.lean-lang.org/repos/verso/graph?m=refman-no-opt-args/build/.total//c.o+time&m=refman-no-opt-args/compile//success&m=refman-o0/build/.total//c.o+time&m=refman-o0/compile//success&m=refman/compile//success&n=100&right=success&s=(^radar)|(%5C.total//)), which shows a substantial difference, with -O0 being quite a bit faster as expected.

<img width="883" height="590" alt="image" src="https://github.com/user-attachments/assets/35ba1929-9c41-45d4-9c02-49ab148a8391" />
