### PR TITLE
fix: CI scripts were still generating HTML the old way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,9 @@ jobs:
             - name: Generate HTML (release)
               if: github.event_name == 'release'
               run: |
-                  lake --quiet exe generate-manual --depth 2 --with-word-count "words.txt" --verbose --without-html-single
+                  # Extract version from release tag (remove 'v' prefix)
+                  VERSION=${GITHUB_REF#refs/tags/v}
+                  ./generate-html.sh --mode production --version "$VERSION"
 
             - name: Check Manual Examples are Isolated
               run: |
@@ -289,12 +291,13 @@ jobs:
                   echo "message=$(git log -1 --pretty=format:"%s")" >> "$GITHUB_OUTPUT"
 
             # When a release is created in GH, push to the main site without proofreading info
+            # This is lean-reference-manual.netlify.app
             - name: Deploy releases when tags are pushed
               id: deploy-release
               uses: nwtgck/actions-netlify@v2.0
               if: github.event_name == 'release'
               with:
-                  publish-dir: _out/html-multi
+                  publish-dir: _out/site/reference
                   production-branch: main
                   production-deploy: true
                   github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge-main-nightly.yml
+++ b/.github/workflows/merge-main-nightly.yml
@@ -90,7 +90,7 @@ jobs:
 
             - name: Generate HTML
               run: |
-                  lake exe generate-manual --depth 2 --without-html-single
+                  ./generate-html.sh --mode preview
 
             - name: Commit and push
               run: |

--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -102,7 +102,7 @@ jobs:
             - name: Generate HTML (non-release)
               id: generate
               run: |
-                  lake --quiet exe generate-manual --depth 2 --with-word-count "words.txt" --verbose --without-html-single
+                  ./generate-html.sh --mode preview
 
             - name: Report status to Lean PR
               if: always() && github.repository == 'leanprover/reference-manual'

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -145,7 +145,7 @@ jobs:
             - name: Generate HTML
               if: steps.check-update.outputs.update-needed == 'true'
               run: |
-                  lake exe generate-manual --depth 2 --without-html-single
+                  ./generate-html.sh --mode preview
 
             - name: Commit and push changes
               id: commit


### PR DESCRIPTION
This meant that circular cross-references with the tutorials didn't work, as the tutorial's xref's weren't present for the manual, and the build would fail due to broken links.
