### PR TITLE
doc: update release notes title to v4.28.0-rc1

### DIFF
--- a/Manual/Releases/v4_28_0.lean
+++ b/Manual/Releases/v4_28_0.lean
@@ -13,7 +13,7 @@ open Verso.Genre
 open Verso.Genre.Manual
 open Verso.Genre.Manual.InlineLean
 
-#doc (Manual) "Lean 4.28.0 (2026-01-26)" =>
+#doc (Manual) "Lean 4.28.0-rc1 (2026-01-26)" =>
 %%%
 tag := "release-v4.28.0"
 file := "v4.28.0"


### PR DESCRIPTION
The release notes page title should show the RC version for RC releases.