### PR TITLE
feat: examples of unexpanders

### DIFF
--- a/Manual/NotationsMacros/Notations.lean
+++ b/Manual/NotationsMacros/Notations.lean
@@ -187,6 +187,36 @@ When the expansion consists of the application of a function defined in the glob
 The new notation will be displayed in {tech}[proof states], error messages, and other output from Lean when matching function application terms otherwise would have been displayed.
 As with custom operators, Lean does not track whether the notation was used in the original term; it is used at every opportunity in Lean's output.
 
+:::example "Notations, Defined Functions, and Unexpanders"
+When a notation does not expand to the application of a defined function, no unexpander is generated.
+Here, the notation expands to an anonymous function:
+```lean
+notation "[" start " ⇒ " stop "]" => fun x => x > start && x < stop
+```
+
+Because there is no named function in the expansion, no unexpander can be generated:
+```lean (name := noUnexp)
+#check [5 ⇒ 8]
+```
+```leanOutput noUnexp
+fun x => decide (x > 5) && decide (x < 8) : Nat → Bool
+```
+
+Using a named function results in an unexpander, which is used for terms that consist of applications of {name}`between`:
+```lean
+def between (start stop : Nat) : Nat → Prop :=
+  fun x => x > start && x < stop
+
+notation "[" start " ⇒' " stop "]" => between start stop
+```
+```lean (name := withUnexp)
+#check [5 ⇒' 8]
+```
+```leanOutput withUnexp
+[5 ⇒' 8] : Nat → Prop
+```
+:::
+
 # Operators and Notations
 %%%
 tag := "operators-and-notations"

--- a/Manual/NotationsMacros/Operators.lean
+++ b/Manual/NotationsMacros/Operators.lean
@@ -331,3 +331,40 @@ When attempting to prove that {lean}`∀ n, n ≥ 8 → (perhapsFactorial n).isN
 ```
 ::::
 :::::
+
+:::example "Infix Operators, Defined Functions, and Unexpanders"
+When an operator does not expand to the application of a defiend function, no unexpander is generated.
+Here, the postfix interrobang expands to an anonymous function that takes a factorial if its argument is not too large.
+
+```lean
+def fact : Nat → Nat
+  | 0 => 1
+  | n+1 => (n + 1) * fact n
+
+set_option quotPrecheck false in
+postfix:90 "‽" => fun (n : Nat) => if n < 8 then some (fact n) else none
+```
+
+Because there is no named function in the expansion, no unexpander can be generated:
+```lean (name := noUnexp)
+#check 7‽
+```
+```leanOutput noUnexp
+(fun n => if n < 8 then some (fact n) else none) 7 : Option Nat
+```
+
+Using a named function results in an unexpander, which is used for terms that consist of applications of {name}`perhapsFactorial`:
+```lean
+def perhapsFactorial (n : Nat) : Option Nat :=
+  if n < 8 then some (fact n) else none
+
+postfix:90 "‽'" => perhapsFactorial
+
+```
+```lean (name := withUnexp)
+#check 7‽'
+```
+```leanOutput withUnexp
+7‽' : Option Nat
+```
+:::


### PR DESCRIPTION
Adds examples of both present and missing unexpanders for operators.
