### PR TITLE
feat: add a domain for configuration files

### DIFF
--- a/Manual/BuildTools/Lake/Config.lean
+++ b/Manual/BuildTools/Lake/Config.lean
@@ -63,7 +63,7 @@ TOML files denote _tables_, which map keys to values.
 Values may consist of strings, numbers, arrays of values, or further tables.
 Because TOML allows considerable flexibility in file structure, this reference documents the values that are expected rather than the specific syntax used to produce them.
 
-The contents of `lakefile.toml` should denote a TOML table that describes a Lean package.
+The contents of {configFile}`lakefile.toml` should denote a TOML table that describes a Lean package.
 This configuration consists of both scalar fields that describe the entire package, as well as the following fields that contain arrays of further tables:
  * `require`
  * `lean_lib`
@@ -732,6 +732,7 @@ tag := "lake-config-lean"
 
 The Lean format for Lake {tech}[package configuration] files provides a domain-specific language for the declarative features that are supported in the TOML format.
 Additionally, it provides the ability to write Lean code to implement any necessary build logic that is not expressible declaratively.
+The Lean configuration file is named {configFile}`lakefile.lean`.
 
 Because the Lean format is a Lean source file, it can be edited using all the features of the Lean language server.
 Additionally, Lean's metaprogramming framework allows elaboration-time side effects to be used to implement features such as configuration steps that are conditional on the current platform.

--- a/Manual/Meta.lean
+++ b/Manual/Meta.lean
@@ -37,6 +37,7 @@ import Manual.Meta.SpliceContents
 import Manual.Meta.Markdown
 import Manual.Meta.Namespace
 import Manual.Meta.SectionNotes
+import Manual.Meta.ConfigFile
 
 
 open Verso ArgParse Doc Elab Genre.Manual Html Code Highlighted.WebAssets

--- a/Manual/Meta/ConfigFile.lean
+++ b/Manual/Meta/ConfigFile.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+
+import Lean.Elab.Command
+import Lean.Elab.InfoTree
+
+import Verso
+import Verso.Doc.ArgParse
+import Verso.Doc.Elab.Monad
+import VersoManual
+import Verso.Code
+
+import SubVerso.Highlighting
+import SubVerso.Examples
+
+
+open Verso.Genre.Manual
+
+namespace Manual
+
+def configFileDomain := `Manual.configFile
+
+open Verso.Search in
+def configFileDomainMapper : DomainMapper where
+  displayName := "Configuration File"
+  className := "config-file-domain"
+  dataToSearchables :=
+  "(domainData) =>
+  Object.entries(domainData.contents).map(([key, value]) => ({
+    searchKey: key,
+    address: `${value[0].address}#${value[0].id}`,
+    domainId: 'Manual.configFile',
+    ref: value,
+  }))"
+
+inline_extension Inline.configFile (filename : String) where
+  init st := st
+    |>.setDomainTitle configFileDomain "Configuration Files"
+    |>.setDomainDescription configFileDomain "Descriptions of files used to configure Lean and its associated tooling"
+    |>.addQuickJumpMapper configFileDomain (configFileDomainMapper.setFont { family := .code })
+  data := .str filename
+  traverse id data _ := do
+    let .str filename := data
+      | logError s!"Failed to deserialize {data} as a string for the filename"
+        pure none
+    let path ← (·.path) <$> read
+    let _ ← Verso.Genre.Manual.externalTag id path filename
+    modify fun st => st.saveDomainObject configFileDomain filename id
+    pure none
+
+  toHtml :=
+    open Verso.Output.Html in
+    open Verso.Doc.Html in
+    some fun _ id data _ => do
+      let .str filename := data
+        | HtmlT.logError s!"Failed to deserialize {data} as a string for the filename"
+          pure .empty
+      let xref ← HtmlT.state
+      let idAttr := xref.htmlId id
+      return {{<code {{idAttr}}>{{filename}}</code>}}
+
+  toTeX := none
+
+open Verso.Doc.Elab
+open Lean.Doc.Syntax
+open Lean
+
+@[role]
+def configFile : RoleExpanderOf Unit
+  | (), inlines => do
+    let #[arg] := inlines
+      | throwError "Expected exactly one argument"
+    let `(inline|code( $cmdName:str )) := arg
+      | throwErrorAt arg "Expected code literal with the config file's name"
+    let filename := cmdName.getString
+
+    `(show Verso.Doc.Inline Verso.Genre.Manual from
+      .other (Manual.Inline.configFile $(quote filename)) #[.code $(quote filename)])


### PR DESCRIPTION
This allows configuration files to be found by filename in the search box, and can enable automatic linking as well.
