### PR TITLE
doc: update IndexMap tutorial for lean4 grind changes

### DIFF
--- a/Tutorial/Grind/IndexMap.lean
+++ b/Tutorial/Grind/IndexMap.lean
@@ -675,14 +675,14 @@ Trying again with {anchorName eraseSwap}`eraseSwap`, everything goes through cle
   | some i =>
     if w : i = m.size - 1 then
       { indices := m.indices.erase a
-        keys    := m.keys.pop
-        values  := m.values.pop }
+        keys := m.keys.pop
+        values := m.values.pop }
     else
       let lastKey := m.keys.back
       let lastValue := m.values.back
       { indices := (m.indices.erase a).insert lastKey i
-        keys    := m.keys.pop.set i lastKey
-        values  := m.values.pop.set i lastValue }
+        keys := m.keys.pop.set i lastKey
+        values := m.values.pop.set i lastValue }
   | none => m
 ```
 
@@ -913,14 +913,14 @@ If the key is not present, the map is unchanged.
   | some i =>
     if w : i = m.size - 1 then
       { indices := m.indices.erase a
-        keys    := m.keys.pop
-        values  := m.values.pop }
+        keys := m.keys.pop
+        values := m.values.pop }
     else
       let lastKey := m.keys.back
       let lastValue := m.values.back
       { indices := (m.indices.erase a).insert lastKey i
-        keys    := m.keys.pop.set i lastKey
-        values  := m.values.pop.set i lastValue }
+        keys := m.keys.pop.set i lastKey
+        values := m.values.pop.set i lastValue }
   | none => m
 
 /-! ### Verification theorems (not exhaustive) -/

--- a/extended-examples/IndexMapGrind.lean
+++ b/extended-examples/IndexMapGrind.lean
@@ -742,14 +742,14 @@ right_3 : a_2 ∈ m.indices
   | some i =>
     if w : i = m.size - 1 then
       { indices := m.indices.erase a
-        keys    := m.keys.pop
-        values  := m.values.pop }
+        keys := m.keys.pop
+        values := m.values.pop }
     else
       let lastKey := m.keys.back
       let lastValue := m.values.back
       { indices := (m.indices.erase a).insert lastKey i
-        keys    := m.keys.pop.set i lastKey
-        values  := m.values.pop.set i lastValue }
+        keys := m.keys.pop.set i lastKey
+        values := m.values.pop.set i lastValue }
   | none => m
 -- ANCHOR_END: eraseSwap_init
 stop discarding
@@ -788,14 +788,14 @@ If the key is not present, the map is unchanged.
   | some i =>
     if w : i = m.size - 1 then
       { indices := m.indices.erase a
-        keys    := m.keys.pop
-        values  := m.values.pop }
+        keys := m.keys.pop
+        values := m.values.pop }
     else
       let lastKey := m.keys.back
       let lastValue := m.values.back
       { indices := (m.indices.erase a).insert lastKey i
-        keys    := m.keys.pop.set i lastKey
-        values  := m.values.pop.set i lastValue }
+        keys := m.keys.pop.set i lastKey
+        values := m.values.pop.set i lastValue }
   | none => m
 -- ANCHOR_END: eraseSwap
 


### PR DESCRIPTION
## Summary

Update the IndexMap tutorial and backing code to reflect changes from lean4 PRs:
- https://github.com/leanprover/lean4/pull/12111
- https://github.com/leanprover/lean4/pull/12115
- https://github.com/leanprover/lean4/pull/12120

### Changes

- `macro_rules` → `local macro_rules` for `get_elem_tactic_extensible`
- Add `size_values` theorem alongside `size_keys`
- Rename `mem_indices_of_mem` → `mem_indices` with `@[local grind _=_]`
- Update expected error messages to match new grind output (hypotheses changed with new configuration)

🤖 Prepared with Claude Code