### PR TITLE
fix: improve clarity of import without modifiers in modules

### DIFF
--- a/Manual/SourceFiles.lean
+++ b/Manual/SourceFiles.lean
@@ -265,6 +265,7 @@ $[public]? $[meta]? import $[all]? $mod:ident
 
 :::paragraph
 All imports to a module must themselves be modules.
+Without modifiers, the imported module's public scope is added to the current module's private scope. The imported module is not made available to modules that import the current module.
 The modifiers have the following meanings:
 
 : {keyword}`public`


### PR DESCRIPTION
Improves the clarity of the description of unmodified `import`. Zulip comment: [#general > Discussion thread for Lean Language Reference @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Discussion.20thread.20for.20Lean.20Language.20Reference/near/571270482)
