### PR TITLE
chore: change RC URLs and add a warning

### DIFF
--- a/Manual/Meta.lean
+++ b/Manual/Meta.lean
@@ -162,6 +162,37 @@ span.TODO {
     some <| fun go _ _ content => do
       pure {{<span class="TODO">{{← content.mapM go}}</span>}}
 
+def Block.warn : Block where
+  name := `Manual.warn
+
+@[directive_expander warn]
+def warn : DirectiveExpander
+  | args, blocks => do
+    ArgParse.done.run args
+    let content ← blocks.mapM elabBlock
+    pure #[← `(Block.other Block.warn #[$content,*])]
+
+@[block_extension warn]
+def warn.descr : BlockDescr where
+  traverse _ _ _ := pure none
+  toTeX := none
+  extraCss := [r#"
+.namedocs.warn { border-color: #cc3333; }
+.namedocs.warn > .label { border-color: #cc3333; color: #a02020; }
+.namedocs.warn > .text { border-top: none; }
+"#]
+  toHtml :=
+    open Verso.Output.Html in
+    some <| fun _ goB _ _ content => do
+      pure {{
+        <div class="namedocs warn">
+          <span class="label">"Warning"</span>
+          <div class="text">
+            {{← content.mapM goB}}
+          </div>
+        </div>
+      }}
+
 def Inline.noVale : Inline where
   name := `Manual.noVale
 

--- a/Manual/Releases/v4_30_0.lean
+++ b/Manual/Releases/v4_30_0.lean
@@ -15,9 +15,14 @@ open Verso.Genre.Manual.InlineLean
 
 #doc (Manual) "Lean 4.30.0-rc1 (2026-04-01)" =>
 %%%
-tag := "release-v4.30.0-rc1"
-file := "v4.30.0-rc1"
+tag := "release-v4.30.0"
+file := "v4.30.0"
 %%%
+
+:::warn
+These release notes describe a _release candidate_, not the final release.
+They may be incomplete and are subject to change.
+:::
 
 For this release, 298 changes landed.
 In addition to the 120 feature additions


### PR DESCRIPTION
This PR changes the release note URLs to match the final release, so we can permalink them in the GitHub releases.

It also adds a warning at the top of release notes for release candidates. In combination with the existing `-rc*` suffix, this should help prevent confusing them with final release notes.