### PR TITLE
docs(delab): fix 'SubExp' -> 'SubExpr' namespace typo

### DIFF
--- a/Manual/NotationsMacros/Delab.lean
+++ b/Manual/NotationsMacros/Delab.lean
@@ -282,7 +282,7 @@ open Lean.PrettyPrinter.Delaborator.SubExpr
 :::paragraph
 The monad {name}`DelabM` is a {tech}[reader monad] that includes access to the current position in the {lean}`Expr`.
 Recursive delaboration is performed by adjusting the reader monad's tracked position, rather than by explicitly passing a subexpression to another function.
-The most important functions for working with subexpressions in delaborators are in the namespace `Lean.PrettyPrinter.Delaborator.SubExp`:
+The most important functions for working with subexpressions in delaborators are in the namespace `Lean.PrettyPrinter.Delaborator.SubExpr`:
  * {name}`getExpr` retrieves the current expression for analysis.
  * {name}`withAppFn` adjusts the current position to be that of the function in an application.
  * {name}`withAppArg` adjusts the current position to be that of the argument in an application


### PR DESCRIPTION
## Summary

The delaborators section of the reference manual (`Manual/NotationsMacros/Delab.lean`, line 285) refers to the namespace \`Lean.PrettyPrinter.Delaborator.SubExp\`, but that namespace does not exist. The real namespace is \`Lean.PrettyPrinter.Delaborator.SubExpr\` — the same name that is \`open\`ed five lines above in the surrounding \`leanSection\`.

Before:
\`\`\`
The most important functions for working with subexpressions in delaborators are in the namespace \`Lean.PrettyPrinter.Delaborator.SubExp\`:
\`\`\`

After:
\`\`\`
The most important functions for working with subexpressions in delaborators are in the namespace \`Lean.PrettyPrinter.Delaborator.SubExpr\`:
\`\`\`

Closes #828

## Testing

Documentation-only one-character change. Verified:
- `Manual/NotationsMacros/Delab.lean:280` already uses `SubExpr` (the correct namespace)
- the listed functions (`getExpr`, `withAppFn`, `withAppArg`, `withAppFnArgs`, `withBindingBody`) live under `Lean.PrettyPrinter.Delaborator.SubExpr`