### PR TITLE
doc: clarify what checks honest library authors must do

### DIFF
--- a/Manual/ValidatingProofs.lean
+++ b/Manual/ValidatingProofs.lean
@@ -64,7 +64,7 @@ The blue ticks indicate that the theorem statement has been successfully elabora
 
 ## Trust
 
-This check is meaningful if one believes the formal theorem statement corresponds to its intended informal meanings and trusts the authors of the imported libraries to be {tech}[honest], that they performed this check, and that no unsound axioms have been declared and used.
+This check is meaningful if one believes the formal theorem statement corresponds to its intended informal meanings and trusts the authors of the imported libraries to be {tech}[honest], that they checked that the theorems in their libraries express their intended informal meanings, and that no unsound axioms have been declared and used.
 
 ## Protection
 


### PR DESCRIPTION
The previous phrasing "[that they performed this check](https://github.com/leanprover/reference-manual/blob/main/Manual/ValidatingProofs.lean#L67C188-L67C207)" was ambiguous. The new phrasing explicitly states who should do what check.

Closes #848
