### PR TITLE
doc: move `replace` tactic next to `have`

### DIFF
--- a/Manual/Tactics.lean
+++ b/Manual/Tactics.lean
@@ -866,6 +866,9 @@ Generally speaking, {tactic}`have` should be used when proving an intermediate l
 :::tactic Lean.Parser.Tactic.tacticHave'
 :::
 
+:::tactic "replace"
+:::
+
 :::tactic Lean.Parser.Tactic.tacticLet__ (show := "let")
 :::
 

--- a/Manual/Tactics/Reference.lean
+++ b/Manual/Tactics/Reference.lean
@@ -319,9 +319,6 @@ tag := "tactic-ref-rw"
 Implemented by {name}`Lean.Elab.Tactic.evalUnfold`.
 :::
 
-:::tactic "replace"
-:::
-
 :::tactic "delta"
 :::
 


### PR DESCRIPTION
`replace` is currently in the Rewriting section (`rw`, etc.), but it seems to belong with `have` instead.