### PR TITLE
fix: remove elan-init script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tutorials.json
 /.verso/verso-xref.json
 /.verso/verso-xref-manifest.json
 words.txt
+elan-init


### PR DESCRIPTION
This was somehow committed by the automation and needs to be removed.
