### PR TITLE
fix: adapt to module system, now 'public section' prints

### DIFF
--- a/Manual/Interaction.lean
+++ b/Manual/Interaction.lean
@@ -505,7 +505,7 @@ intersperse.eq_unfold.{u_1} :
 The {keywordOf Lean.Parser.Command.where}`#where` command displays all the modifications made to the current {tech}[section scope], both in the current scope and in the scopes in which it is nested.
 
 ```lean +fresh (name := scopeInfo)
-section
+public section
 open Nat
 
 namespace A
@@ -513,21 +513,23 @@ variable (n : Nat)
 namespace B
 
 open List
-set_option pp.funBinderTypes true
+set_option pp.tagAppFns true
 
 #where
 
 end A.B
 end
 ```
-```leanOutput scopeInfo (allowDiff := 1)
+```leanOutput scopeInfo
+public section
+
 namespace A.B
 
 open Nat List
 
 variable (n : Nat)
 
-set_option pp.funBinderTypes true
+set_option pp.tagAppFns true
 ```
 
 :::

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "7866eb5788256eb96567fcc3633fcb0656f60d0d",
+   "rev": "74cdac102c52eb4e0626dd047be79ef8884c67a9",
    "name": "verso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "nightly-testing",


### PR DESCRIPTION
The switch to `pp.tagAppFns` is a hack; Verso's current configuration sets this no matter what we do, so this way we're at least showing the user what they expect to see