### PR TITLE
chore: bump to 2026-07-12

### DIFF
--- a/Manual/BuildTools/Lake.lean
+++ b/Manual/BuildTools/Lake.lean
@@ -474,6 +474,8 @@ module.c
 module.c.o
 module.c.o.export
 module.c.o.noexport
+module.depHash
+module.depTrace
 module.deps
 module.dynlib
 module.exportInfo
@@ -498,6 +500,7 @@ module.olean
 module.olean.private
 module.olean.server
 module.precompileImports
+module.presetup
 module.setup
 module.transImports
 -/
@@ -519,6 +522,14 @@ The facets available for modules are:
 : `deps`
 
   The module's dependencies (e.g., imports or shared libraries).
+
+: `depHash`
+
+  A hash of a module's build dependencies (e.g., imports, source, plugins).
+
+: `depTrace`
+
+  A data structure representing a module's build dependencies (e.g., imports, source, plugins).
 
 : `olean`
 

--- a/Manual/BuildTools/Lake.lean
+++ b/Manual/BuildTools/Lake.lean
@@ -529,7 +529,7 @@ The facets available for modules are:
 
 : `depTrace`
 
-  A data structure representing a module's build dependencies (e.g., imports, source, plugins).
+  A Lake build trace data structure (i.e., composite hash and modification time) of a module's build dependencies (e.g., imports, source, plugins).
 
 : `olean`
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2026-07-11
+leanprover/lean4:nightly-2026-07-12


### PR DESCRIPTION
depHash and depTrace module facets are now documented, presetup is not as its doc comments indicate it is intended only for internal use
