### PR TITLE
doc: remove duplicate tactic "have"

### DIFF
--- a/Manual/Tactics.lean
+++ b/Manual/Tactics.lean
@@ -857,9 +857,6 @@ tag := "tactic-language-local-defs"
 {tactic}`have` and {tactic}`let` both create local assumptions.
 Generally speaking, {tactic}`have` should be used when proving an intermediate lemma; {tactic}`let` should be reserved for local definitions.
 
-:::tactic "have"
-:::
-
 :::tactic Lean.Parser.Tactic.tacticHave__
 :::
 


### PR DESCRIPTION
This is the same as the `Lean.Parser.Tactic.tacticHave__` below.
