### PR TITLE
doc: fix incorrect subsingleton criteria

### DIFF
--- a/Manual/Language/InductiveTypes/LogicalModel.lean
+++ b/Manual/Language/InductiveTypes/LogicalModel.lean
@@ -149,7 +149,7 @@ A proposition that has at most one inhabitant is called a {deftech}_subsingleton
 Rather than obligating users to _prove_ that there's only one possible proof, a conservative syntactic approximation is used to check whether a proposition is a subsingleton.
 Propositions that fulfill both of the following requirements are considered to be subsingletons:
  * There is at most one constructor.
- * Each of the constructor's parameter types is either a {lean}`Prop`, a parameter, or an index.
+ * Each of the constructor's parameters is either of sort {lean}`Prop`, recursive, or an argument of the type constructor.
 
 :::example "{lean}`True` is a subsingleton"
 {lean}`True` is a subsingleton because it has one constructor, and this constructor has no parameters.
@@ -210,6 +210,17 @@ Eq.rec.{u, v} {α : Sort v} {x : α}
   {y : α} (t : x = y) : motive y t
 ```
 This means that proofs of equality can be used to rewrite the types of non-propositions.
+:::
+
+:::example "{name}`Acc` is a subsingleton"
+{lean}`Acc` is a subsingleton because it has just one constructor, {name}`Acc.intro`.
+This constructor has parameters that are respectively the parameter of `Acc`, the index of `Acc`, and recursive:
+```signature
+Acc.intro.{u} {α : Sort u} {r : α → α → Prop} (x : α) (h : ∀ (y : α), r y x → Acc r y) : Acc r x
+```
+
+Its recursor has a motive of type `(a : α) → Acc r a → Sort v`.
+This means that proofs of accessibility can be used to define well-founded recursive functions with a codomain that is not restricted to propositions.
 :::
 
 ## Reduction


### PR DESCRIPTION
This PR fixes 2 aspects of the subsingleton criteria:
- It's not the constructor parameter _type_ which must be a parameter or index. It's the parameter itself. That's demonstrated by `Eq`.
- A constructor parameter doesn't need to be a proof or a parameter/index, it can also be recursive. That's demonstrated by `Acc`. This example has been added to the list of examples, in addition to the criteria fix.

I'm happy to reword the criteria and example. Note that I used the word "argument" to mean both "parameter" and "index" as is done previously in the reference manual:
https://github.com/leanprover/reference-manual/blob/c8193e06c01c3aa6df516ad2df466cd7573f7f52/Manual/Language/InductiveTypes.lean#L87

Here is a more formal description of the criteria:
https://github.com/digama0/lean-type-theory/blob/0ba178704380d2fad751f020d461b293f47e36d5/axioms.tex#L148

<img width="1023" height="747" alt="subsingleton" src="https://github.com/user-attachments/assets/fa2ac41d-e22d-42b8-812b-39e46fe2c24e" />
