### PR TITLE
doc: fix typo in floating-point literals example

### DIFF
--- a/Manual/BasicTypes/Float.lean
+++ b/Manual/BasicTypes/Float.lean
@@ -231,7 +231,7 @@ Instead, floating-point literals are resolved via the appropriate instances of t
 
 The term
 ```leanTerm
-(-2.523 : Float)
+(-2.2523 : Float)
 ```
 is syntactic sugar for
 ```leanTerm


### PR DESCRIPTION
Line 238 is `(Neg.neg (OfScientific.ofScientific 22523 true 4) : Float)` which evaluates to -2.2523, not -2.523.