### PR TITLE
chore: update plausible.io snippet to newest version

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -13,7 +13,11 @@ open Verso.Genre.Manual.InlineLean
 
 open Verso.Output.Html in
 def plausible := {{
-    <script defer="defer" data-domain="lean-lang.org" src="https://plausible.io/js/script.outbound-links.js"></script>
+    <script async src="https://plausible.io/js/pa-RTua_4FfKHhfAvAc3liZd.js"></script>
+    <script>{{Verso.Output.Html.text false r#"
+      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+      plausible.init()
+    "#}}</script>
   }}
 
 open Verso.Output.Html in


### PR DESCRIPTION
This PR update the Plausible.io snippet used for web analytics on lean-lang.org. Plausible does not store persistent or identifying data. See their [privacy statement](https://plausible.io/privacy-focused-web-analytics) for more info.